### PR TITLE
Device wake - improve  stability

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -26,3 +26,4 @@ lib_deps =
     AsyncTCP@>=1.1.1
     ArduinoJson@>=6.15.2
     ESP32SSPD@>=1.1.0
+;monitor_filters= default, esp32_exception_decoder

--- a/src/hardware/pmu.cpp
+++ b/src/hardware/pmu.cpp
@@ -63,11 +63,6 @@ void IRAM_ATTR  pmu_irq( void ) {
     if ( xHigherPriorityTaskWoken ) {
         portYIELD_FROM_ISR();
     }
-    /*
-     * fast wake up from IRQ
-     */
-    // rtc_clk_cpu_freq_set(RTC_CPU_FREQ_240M);
-    setCpuFrequencyMhz(240);
 }
 
 void pmu_standby( void ) {
@@ -175,6 +170,8 @@ void pmu_loop( TTGOClass *ttgo ) {
      * handle IRQ event
      */
     if ( xEventGroupGetBitsFromISR( pmu_event_handle ) & PMU_EVENT_AXP_INT ) {
+        setCpuFrequencyMhz(240);
+        
         ttgo->power->readIRQ();
         if (ttgo->power->isVbusPlugInIRQ()) {
             powermgm_set_event( POWERMGM_PMU_BATTERY );


### PR DESCRIPTION
The crash below could be easily repeated by switching device on then off repeatedly.  
This pull request resolves this issue

Guru Meditation Error: Core 1 panic'ed (Interrupt wdt timeout on CPU1)
Core 1 register dump:
PC : 0x40090332 PS : 0x00060034 A0 : 0x8008f4ef A1 : 0x3ffbe650
A2 : 0x3ffb84c8 A3 : 0x3ffbc7f8 A4 : 0x00000001 A5 : 0x00000001
A6 : 0x00060023 A7 : 0x00000000 A8 : 0x3ffbc7f8 A9 : 0x3ffbc7f8
A10 : 0x00000019 A11 : 0x00000019 A12 : 0x00000001 A13 : 0x00000001
A14 : 0x00060021 A15 : 0x00000000 SAR : 0x00000004 EXCCAUSE: 0x00000006
EXCVADDR: 0x00000000 LBEG : 0x400014fd LEND : 0x4000150d LCOUNT : 0xffffffff
Core 1 was running in ISR context:
EPC1 : 0x4008e7c2 EPC2 : 0x00000000 EPC3 : 0x00000000 EPC4 : 0x40090332

Backtrace: 0x40090332:0x3ffbe650 0x4008f4ec:0x3ffbe670 0x4008d553:0x3ffbe690 0x4008d5bd:0x3ffbe6d0 0x40118659:0x3ffbe6f0 0x40117a01:0x3ffbe710 0x40117d09:0x3ffbe730 0x40081412:0x3ffbe780 0x40081485:0x3ffbe7b0 0x40087fb1:0x3ffbe7d0 0x401e0a97:0x3ffbc6e0 0x4011e226:0x3ffbc700 0x4008f165:0x3ffbc720 0x4008d74d:0x3ffbc740
#0 0x40090332:0x3ffbe650 in vListInsert at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/freertos/list.c:188
#1 0x4008f4ec:0x3ffbe670 in vTaskPlaceOnEventList at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/freertos/tasks.c:3507
#2 0x4008d553:0x3ffbe690 in xQueueGenericReceive at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/freertos/queue.c:1996
#3 0x4008d5bd:0x3ffbe6d0 in xQueueTakeMutexRecursive at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/freertos/queue.c:1996
#4 0x40118659:0x3ffbe6f0 in i2cApbChangeCallback at C:\Users\Chris.platformio\packages\framework-arduinoespressif32\cores\esp32/esp32-hal-i2c.c:463
#5 0x40117a01:0x3ffbe710 in triggerApbChangeCallback at C:\Users\Chris.platformio\packages\framework-arduinoespressif32\cores\esp32/esp32-hal-cpu.c:213
#6 0x40117d09:0x3ffbe730 in setCpuFrequencyMhz at C:\Users\Chris.platformio\packages\framework-arduinoespressif32\cores\esp32/esp32-hal-cpu.c:213
#7 0x40081412:0x3ffbe780 in pmu_irq() at src\hardware/pmu.cpp:70
#8 0x40081485:0x3ffbe7b0 in __onPinInterrupt at C:\Users\Chris.platformio\packages\framework-arduinoespressif32\cores\esp32/esp32-hal-gpio.c:274
#9 0x40087fb1:0x3ffbe7d0 in _xt_lowint1 at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/freertos/xtensa_vectors.S:1154
#10 0x401e0a97:0x3ffbc6e0 in esp_pm_impl_waiti at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/esp32/pm_esp32.c:492
#11 0x4011e226:0x3ffbc700 in esp_vApplicationIdleHook at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/esp32/freertos_hooks.c:108
#12 0x4008f165:0x3ffbc720 in prvIdleTask at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/freertos/tasks.c:3507
#13 0x4008d74d:0x3ffbc740 in vPortTaskWrapper at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/freertos/port.c:355 (discriminator 1)

Core 0 register dump:
PC : 0x4008e7cd PS : 0x00060034 A0 : 0x8008f19d A1 : 0x3ffbe150
A2 : 0x3ffbf9d8 A3 : 0x0000cdcd A4 : 0xb33fffff A5 : 0x00000001
A6 : 0x00060021 A7 : 0x0000abab A8 : 0x0000abab A9 : 0x3ffcfae4
A10 : 0x00000003 A11 : 0x00060023 A12 : 0x00060021 A13 : 0x0000003f
A14 : 0x0000002a A15 : 0x3ffe52c0 SAR : 0x00000016 EXCCAUSE: 0x00000006
EXCVADDR: 0x00000000 LBEG : 0x4000c2e0 LEND : 0x4000c2f6 LCOUNT : 0x00000000

Backtrace: 0x4008e7cd:0x3ffbe150 0x4008f19a:0x3ffbe180 0x4008d83b:0x3ffbe1a0 0x400901a9:0x3ffbe1c0 0x40087fba:0x3ffbe1d0 0x40167a97:0x3ffe5150 0x40168002:0x3ffe5210 0x401680b1:0x3ffe5230 0x40168178:0x3ffe5260 0x401666a5:0x3ffe52e0 0x401666e6:0x3ffe53a0 0x4016855d:0x3ffe53d0 0x401685f3:0x3ffe5440 0x40190051:0x3ffe5490 0x4019115a:0x3ffe54b0 0x40191169:0x3ffe54f0 0x401495f1:0x3ffe5510 0x40149a04:0x3ffe5550 0x4014a705:0x3ffe55c0 0x4014a7be:0x3ffe5610 0x40145c51:0x3ffe5660 0x40145eac:0x3ffe56b0 0x40145ec3:0x3ffe56f0 0x40148c30:0x3ffe5710 0x40148d5a:0x3ffe5730 0x40094553:0x3ffe5750 0x4008d74d:0x3ffe5790
#0 0x4008e7cd:0x3ffbe150 in vPortCPUAcquireMutexIntsDisabledInternal at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/freertos/tasks.c:3507
(inlined by) vPortCPUAcquireMutexIntsDisabled at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/freertos/portmux_impl.h:98
(inlined by) vTaskEnterCritical at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/freertos/tasks.c:4201
#1 0x4008f19a:0x3ffbe180 in xTaskIncrementTick at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/freertos/tasks.c:3507
#2 0x4008d83b:0x3ffbe1a0 in xPortSysTickHandler at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/freertos/port.c:355 (discriminator 1)
#3 0x400901a9:0x3ffbe1c0 in _frxt_timer_int at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/freertos/portasm.S:303
#4 0x40087fba:0x3ffbe1d0 in _xt_lowint1 at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/freertos/xtensa_vectors.S:1154
#5 0x40167a97:0x3ffe5150 in SHA1Transform at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/wpa_supplicant/src/crypto/sha1-internal.c:215
#6 0x40168002:0x3ffe5210 in SHA1Update at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/wpa_supplicant/src/crypto/sha1-internal.c:267
#7 0x401680b1:0x3ffe5230 in SHA1Final at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/wpa_supplicant/src/crypto/sha1-internal.c:298
#8 0x40168178:0x3ffe5260 in sha1_vector at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/wpa_supplicant/src/crypto/sha1-internal.c:45
#9 0x401666a5:0x3ffe52e0 in hmac_sha1_vector at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/wpa_supplicant/src/crypto/sha1.c:94
#10 0x401666e6:0x3ffe53a0 in hmac_sha1 at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/wpa_supplicant/src/crypto/sha1.c:111
#11 0x4016855d:0x3ffe53d0 in pbkdf2_sha1_f at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/wpa_supplicant/src/crypto/sha1-pbkdf2.c:54
#12 0x401685f3:0x3ffe5440 in pbkdf2_sha1 at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/wpa_supplicant/src/crypto/sha1-pbkdf2.c:91
#13 0x40190051:0x3ffe5490 in wpa_set_bss at ??:?
#14 0x4019115a:0x3ffe54b0 in wpa_config_bss at ??:?
#15 0x40191169:0x3ffe54f0 in wpa_sta_connect at ??:?
#16 0x401495f1:0x3ffe5510 in cnx_sta_connect_led_timer_cb at ??:?
#17 0x40149a04:0x3ffe5550 in cnx_sta_connect_led_timer_cb at ??:?
#18 0x4014a705:0x3ffe55c0 in cnx_remove_all_rc at ??:?
#19 0x4014a7be:0x3ffe5610 in cnx_start_handoff_cb at ??:?
#20 0x40145c51:0x3ffe5660 in clear_bss_queue at ??:?
#21 0x40145eac:0x3ffe56b0 in clear_bss_queue at ??:?
#22 0x40145ec3:0x3ffe56f0 in scan_enter_oper_channel_process at ??:?
#23 0x40148c30:0x3ffe5710 in wifi_station_stop at ??:?
#24 0x40148d5a:0x3ffe5730 in ieee80211_timer_do_process at ??:?
#25 0x40094553:0x3ffe5750 in ppTask at ??:?
#26 0x4008d74d:0x3ffe5790 in vPortTaskWrapper at /home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/freertos/port.c:355 (discriminator 1)