### PR TITLE
Honor wifi auto-on on reboot

### DIFF
--- a/src/hardware/wifictl.cpp
+++ b/src/hardware/wifictl.cpp
@@ -457,6 +457,12 @@ void wifictl_off( void ) {
   while( wifictl_get_event( WIFICTL_OFF_REQUEST | WIFICTL_ON_REQUEST ) ) { 
     yield();
   }
+
+  if ( !wifictl_get_event( WIFICTL_ACTIVE ) ) {
+    log_i("wifictl not active");
+    return;
+  }
+
   wifictl_set_event( WIFICTL_OFF_REQUEST );
   vTaskResume( _wifictl_Task );
 }

--- a/src/my-ttgo-watch.ino
+++ b/src/my-ttgo-watch.ino
@@ -86,7 +86,8 @@ void setup()
      *
      */
 
-    wifictl_on();
+    if (wifictl_get_autoon() && (ttgo->power->isChargeing() || ttgo->power->isVBUSPlug() || (ttgo->power->getBattVoltage() > 3400)))
+        wifictl_on();
 
     splash_screen_stage_finish( ttgo );
     display_set_brightness( display_get_brightness() );


### PR DESCRIPTION
The wifi is automatically turned on when it reboots, even if the config has auto-on off.
This change will leave wifi off if configured to not turn on, or when the battery voltage is low, unless it is plugged in.
The standby functions were requesting that the wifi be turned off, and were crashing if it had never turned on, so I added a check that the wifi status is active before turning it off - I'm uncertain whether this is ok, or whether a different process should be folllowed.