### PR TITLE
Small fixes for PMU Settings, Vibe on silent wake, power save for silent wake/

### DIFF
--- a/src/hardware/pmu.cpp
+++ b/src/hardware/pmu.cpp
@@ -165,8 +165,8 @@ void pmu_read_config( void ) {
             }
             else {
                 pmu_config.silence_wakeup = doc["silence_wakeup"] | false;
-                pmu_config.silence_wakeup_time = doc["compute_percent"] | 60;
-                pmu_config.silence_wakeup_time_vbplug = doc["compute_percent"] | 3;
+                pmu_config.silence_wakeup_time = doc["silence_wakeup_time"] | 60;
+                pmu_config.silence_wakeup_time_vbplug = doc["silence_wakeup_time_vbplug"] | 3;
                 pmu_config.experimental_power_save = doc["experimental_power_save"] | false;
                 pmu_config.compute_percent = doc["compute_percent"] | false;
                 pmu_config.high_charging_target_voltage = doc["high_charging_target_voltage"] | false;

--- a/src/hardware/powermgm.cpp
+++ b/src/hardware/powermgm.cpp
@@ -84,7 +84,12 @@ void powermgm_loop( void ) {
 
         log_i("go wakeup");
 
-        setCpuFrequencyMhz(240);
+        //Network transfer times are likely a greater time consumer than actual computational time
+        if (powermgm_get_event(POWERMGM_SILENCE_WAKEUP_REQUEST)){
+            setCpuFrequencyMhz(80);
+        }else{
+            setCpuFrequencyMhz(240);
+        }
 
         pmu_wakeup();
         bma_wakeup();
@@ -110,6 +115,10 @@ void powermgm_loop( void ) {
         }
     }        
     else if( powermgm_get_event( POWERMGM_STANDBY_REQUEST ) ) {
+        
+        //Save info to avoid buzz when standby after silent wake
+        bool noBuzz = powermgm_get_event(POWERMGM_SILENCE_WAKEUP |POWERMGM_SILENCE_WAKEUP_REQUEST);
+        
         powermgm_clear_event( POWERMGM_STANDBY | POWERMGM_SILENCE_WAKEUP | POWERMGM_WAKEUP );
 
         if ( !display_get_block_return_maintile() ) {
@@ -136,7 +145,7 @@ void powermgm_loop( void ) {
         powermgm_set_event( POWERMGM_STANDBY );
 
         if ( !blectl_get_enable_on_standby() ) {
-            motor_vibe(3);
+            if (!noBuzz) motor_vibe(3);  //Only buzz if a non silent wake was performed
             delay(50);
             log_i("go standby");
             setCpuFrequencyMhz( 80 );


### PR DESCRIPTION
1.) Fix PMU read settings had wrong parameters for json doc read.
2.) Stop buzz when going to standby from silent wake.
3.) Reduced CPU frequency on silent wake, network communication time is likely greater than processing time needed.