### PR TITLE
Feature/add powermanagement for sound

### DIFF
--- a/src/hardware/powermgm.cpp
+++ b/src/hardware/powermgm.cpp
@@ -37,6 +37,7 @@
 #include "touch.h"
 #include "display.h"
 #include "rtcctl.h"
+#include "sound.h"
 
 #include "gui/mainbar/mainbar.h"
 
@@ -103,6 +104,7 @@ void powermgm_loop( void ) {
 
         pmu_wakeup();
         bma_wakeup();
+        sound_wakeup();
         display_wakeup( powermgm_get_event( POWERMGM_SILENCE_WAKEUP_REQUEST )?true:false );
 
         timesyncToSystem();
@@ -148,6 +150,7 @@ void powermgm_loop( void ) {
 
         bma_standby();
         pmu_standby();
+        sound_standby();
         wifictl_standby();
         blectl_standby();
 

--- a/src/hardware/sound.cpp
+++ b/src/hardware/sound.cpp
@@ -57,10 +57,7 @@ void sound_setup( void ) {
         return;
 
     sound_read_config();
-
-    //!Turn on the audio power
-    sound_set_enabled(true);
-
+    
     //out->SetPinout(I2S_BCLK, I2S_LRC, I2S_DOUT);
     out = new AudioOutputI2S();
     out->SetPinout( TWATCH_DAC_IIS_BCK, TWATCH_DAC_IIS_WS, TWATCH_DAC_IIS_DOUT );
@@ -76,7 +73,9 @@ void sound_standby( void ) {
 }
 
 void sound_wakeup( void ) {
-    sound_set_enabled(true);
+    // to avoid additional power consumtion when waking up, audio is only enabled when 
+    // a 'play sound' method is called
+    // this would be the place to play a wakeup sound
 }
 
 /**
@@ -178,8 +177,9 @@ bool sound_get_enabled_config( void ) {
 
 void sound_set_enabled_config( bool enable ) {
     sound_config.enable = enable;
-
-    sound_set_enabled(enable);
+    if ( ! sound_config.enable) {
+        sound_set_enabled( false );
+    }
     sound_save_config();
 }
 

--- a/src/hardware/sound.h
+++ b/src/hardware/sound.h
@@ -32,6 +32,23 @@
     } sound_config_t;
 
     /*
+    * @brief put sound output to standby (disable)
+    */
+    void sound_standby( void );
+
+    /*
+    * @brief wakeup sound output
+    */
+    void sound_wakeup( void );
+    
+    /**
+     * @brief enable or disable the power output for AXP202_LDO3
+     * 
+     * @param enable = true sets the AXP202_LDO3 power output to high false to low
+     */
+    void sound_set_enabled( bool enabled = true );
+
+    /*
      * @brief play mp3 file from SPIFFS by path/filename
      * 
      * @param   filename    the SPIFFS path to the file to be played
@@ -59,6 +76,11 @@
      * 
      */
     void sound_loop( void );
+    /*
+     * @brief stop all sounds currently playing
+     * 
+     */
+    void sound_stop( void );
     /*
      * @brief save config for sound to spiffs
      */

--- a/src/hardware/sound.h
+++ b/src/hardware/sound.h
@@ -77,11 +77,6 @@
      */
     void sound_loop( void );
     /*
-     * @brief stop all sounds currently playing
-     * 
-     */
-    void sound_stop( void );
-    /*
      * @brief save config for sound to spiffs
      */
     void sound_save_config( void );


### PR DESCRIPTION
**summary**
Disable power for speaker (I2S) via PMU

**Details**
 - Power to audio circuit is now disabled via PMU (AXP202 - LDO3). ``` ttgo->power->setPowerOutPut(AXP202_LDO3, 0);```
 - Sound.cpp now implements _standby_ and _wakeup_ methods to be called by _powermgn.cpp_
 - Audio output (inkl. power) is always disabled unless a sound file is played
 - Power is disabled immediately once a sound stopped playing via and enabled when start playing sound 