### PR TITLE
Install ESP8266Audio library from tarball instead of Git

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -35,5 +35,5 @@ lib_deps =
 	luc-github/ESP32SSDP@>=1.1.1
 	IRremoteESP8266@>=2.7.10
 	PubSubClient@>=2.8
-	https://github.com/earlephilhower/ESP8266Audio#22b52e0ed5aa86a5e5704c5c86d435c8e3e233a0
+	https://codeload.github.com/earlephilhower/ESP8266Audio/legacy.tar.gz/22b52e0ed5aa86a5e5704c5c86d435c8e3e233a0
 	earlephilhower/ESP8266SAM@^1.0


### PR DESCRIPTION
Installing a library from a tarball url is more portable than installing it from a git url, since with the tarball method PlatformIO doesn't depend on any external program (i.e. `git`).

For an example of the problem this solves:
I have Cygwin installed, so I have Git installed, **but** it's the wrong version of Git. I have the Cygwin version of Git, while PlatformIO needs me to have Git for Windows. Because of this, If I run `pio run` or just `pio lib install` in this project (as is), I get some fatal error when it's trying to install the library using Git. See https://github.com/platformio/platformio-core/issues/3703
