### PR TITLE
CryptoTicker widget improvements

### DIFF
--- a/src/app/crypto_ticker/crypto_ticker.cpp
+++ b/src/app/crypto_ticker/crypto_ticker.cpp
@@ -26,9 +26,7 @@
 #include "crypto_ticker_fetch.h"
 #include "crypto_ticker_main.h"
 #include "crypto_ticker_setup.h"
-#ifdef CRYPTO_TICKER_WIDGET
-    #include "crypto_ticker_widget.h"
-#endif // CRYPTO_TICKER_WIDGET
+#include "crypto_ticker_widget.h"
 
 #include "gui/mainbar/main_tile/main_tile.h"
 #include "gui/mainbar/mainbar.h"
@@ -66,14 +64,14 @@ void crypto_ticker_setup( void ) {
 
     // register app and widget icon
     crypto_ticker_app = app_register( "crypto\nticker", &bitcoin_64px, enter_crypto_ticker_event_cb );
-#ifdef CRYPTO_TICKER_WIDGET
-    crypto_ticker_widget_setup();
-#endif // CRYPTO_TICKER_WIDGET
+    
+    if ( crypto_ticker_config.widget ) {
+        crypto_ticker_add_widget();
+    }
 
     // init main and setup tile, see crypto_ticker_main.cpp and crypto_ticker_setup.cpp
     crypto_ticker_main_setup( crypto_ticker_main_tile_num );
     crypto_ticker_setup_setup( crypto_ticker_setup_tile_num );
-
 }
 
 uint32_t crypto_ticker_get_app_main_tile_num( void ) {
@@ -122,10 +120,11 @@ void crypto_ticker_save_config( void ) {
         log_e("Can't open file: %s!", crypto_ticker_JSON_CONFIG_FILE );
     }
     else {
-        SpiRamJsonDocument doc( 1000 );
+        SpiRamJsonDocument doc( 1200 );
 
         doc["symbol"] = crypto_ticker_config.symbol;
         doc["autosync"] = crypto_ticker_config.autosync;
+        doc["widget"] = crypto_ticker_config.widget;
 
         if ( serializeJsonPretty( doc, file ) == 0) {
             log_e("Failed to write config file");
@@ -155,6 +154,7 @@ void crypto_ticker_load_config( void ) {
             else {
                 strlcpy( crypto_ticker_config.symbol, doc["symbol"], sizeof( crypto_ticker_config.symbol ) );
                 crypto_ticker_config.autosync = doc["autosync"].as<bool>();
+                crypto_ticker_config.widget = doc["widget"].as<bool>();
             }        
             doc.clear();
         }

--- a/src/app/crypto_ticker/crypto_ticker.h
+++ b/src/app/crypto_ticker/crypto_ticker.h
@@ -31,6 +31,7 @@
     typedef struct {
             char symbol[10] = "";
             bool autosync = true;
+            bool widget = false;
         } crypto_ticker_config_t;
 
 

--- a/src/app/crypto_ticker/crypto_ticker_main.cpp
+++ b/src/app/crypto_ticker/crypto_ticker_main.cpp
@@ -25,12 +25,8 @@
 #include "crypto_ticker.h"
 #include "crypto_ticker_fetch.h"
 #include "crypto_ticker_main.h"
-
-#ifdef CRYPTO_TICKER_WIDGET
-
 #include "crypto_ticker_widget.h"
 
-#endif // CRYPTO_TICKER_WIDGET
 
 #include "gui/mainbar/app_tile/app_tile.h"
 #include "gui/mainbar/main_tile/main_tile.h"
@@ -149,6 +145,11 @@ void crypto_ticker_main_setup( uint32_t tile_num ) {
     crypto_ticker_main_event_handle = xEventGroupCreate();
 
     wifictl_register_cb( WIFICTL_OFF | WIFICTL_CONNECT, crypto_ticker_main_wifictl_event_cb, "crypto ticker main" );
+
+    
+    crypto_ticker_widget_event_handle = xEventGroupCreate();
+    
+    wifictl_register_cb( WIFICTL_OFF | WIFICTL_CONNECT, crypto_ticker_widget_wifictl_event_cb, "crypto ticker widget" );
 }
 
 bool crypto_ticker_main_wifictl_event_cb( EventBits_t event, void *arg ) {    
@@ -180,12 +181,10 @@ static void exit_crypto_ticker_main_event_cb( lv_obj_t * obj, lv_event_t event )
 static void refresh_crypto_ticker_main_event_cb( lv_obj_t * obj, lv_event_t event ) {
     switch( event ) {
         case( LV_EVENT_CLICKED ):       crypto_ticker_main_sync_request();
-
-#ifdef CRYPTO_TICKER_WIDGET
-
-                                        crypto_ticker_widget_sync_request();
-
-#endif // CRYPTO_TICKER_WIDGET
+                                        crypto_ticker_config_t *crypto_ticker_config = crypto_ticker_get_config();
+                                        if ( crypto_ticker_config->widget ) {
+                                            crypto_ticker_widget_sync_request();
+                                        }
                                         break;
     }
 }

--- a/src/app/crypto_ticker/crypto_ticker_setup.cpp
+++ b/src/app/crypto_ticker/crypto_ticker_setup.cpp
@@ -24,6 +24,7 @@
 
 #include "crypto_ticker.h"
 #include "crypto_ticker_setup.h"
+#include "crypto_ticker_widget.h"
 
 #include "gui/mainbar/mainbar.h"
 #include "gui/statusbar.h"
@@ -41,6 +42,7 @@ LV_IMG_DECLARE(exit_32px);
 static void exit_crypto_ticker_setup_event_cb( lv_obj_t * obj, lv_event_t event );
 static void crypto_ticker_textarea_event_cb( lv_obj_t * obj, lv_event_t event );
 static void crypto_ticker_autosync_switch_event_cb( lv_obj_t * obj, lv_event_t event );
+static void crypto_ticker_widget_onoff_event_handler(lv_obj_t *obj, lv_event_t event);
 
 void crypto_ticker_setup_setup( uint32_t tile_num ) {
 
@@ -106,10 +108,47 @@ void crypto_ticker_setup_setup( uint32_t tile_num ) {
 
     lv_obj_t *crypto_ticker_autosync_switch_label = lv_label_create( crypto_ticker_autosync_switch_cont, NULL);
     lv_obj_add_style( crypto_ticker_autosync_switch_label, LV_OBJ_PART_MAIN, &crypto_ticker_setup_style  );
-    lv_label_set_text( crypto_ticker_autosync_switch_label, "autosync");
+    lv_label_set_text( crypto_ticker_autosync_switch_label, "Autosync");
     lv_obj_align( crypto_ticker_autosync_switch_label, crypto_ticker_autosync_switch_cont, LV_ALIGN_IN_LEFT_MID, 5, 0 );
+
+    lv_obj_t *crypto_ticker_widget_cont = lv_obj_create( crypto_ticker_setup_tile, NULL);
+    lv_obj_set_size( crypto_ticker_widget_cont, lv_disp_get_hor_res( NULL ), 30);
+    lv_obj_add_style( crypto_ticker_widget_cont, LV_OBJ_PART_MAIN, &crypto_ticker_setup_style );
+    lv_obj_align( crypto_ticker_widget_cont, crypto_ticker_autosync_switch_cont, LV_ALIGN_OUT_BOTTOM_MID, 0, 0 );
+    lv_obj_t *crypto_ticker_widget_onoff = lv_switch_create( crypto_ticker_widget_cont, NULL);
+    lv_obj_add_protect( crypto_ticker_widget_onoff, LV_PROTECT_CLICK_FOCUS);
+    lv_obj_add_style( crypto_ticker_widget_onoff, LV_SWITCH_PART_INDIC, mainbar_get_switch_style() );
+    lv_switch_off( crypto_ticker_widget_onoff, LV_ANIM_ON);
+    lv_obj_align( crypto_ticker_widget_onoff, crypto_ticker_widget_cont, LV_ALIGN_IN_RIGHT_MID, -5, 0);
+    lv_obj_set_event_cb( crypto_ticker_widget_onoff, crypto_ticker_widget_onoff_event_handler);
+    lv_obj_t *crypto_ticker_widget_label = lv_label_create( crypto_ticker_widget_cont, NULL);
+    lv_obj_add_style( crypto_ticker_widget_label, LV_OBJ_PART_MAIN, &crypto_ticker_setup_style );
+    lv_label_set_text( crypto_ticker_widget_label, "Widget");
+    lv_obj_align( crypto_ticker_widget_label, crypto_ticker_widget_cont, LV_ALIGN_IN_LEFT_MID, 5, 0);
+
+    
+    if ( crypto_ticker_config->widget )
+        lv_switch_on( crypto_ticker_widget_onoff, LV_ANIM_OFF );
+    else
+        lv_switch_off( crypto_ticker_widget_onoff, LV_ANIM_OFF );
+
 }
 
+
+static void crypto_ticker_widget_onoff_event_handler(lv_obj_t *obj, lv_event_t event) {
+    switch (event) {
+        case ( LV_EVENT_VALUE_CHANGED ):    crypto_ticker_config_t *crypto_config = crypto_ticker_get_config();
+                                            crypto_config->widget = lv_switch_get_state( obj );
+                                            if ( crypto_config->widget ) {
+                                                crypto_ticker_add_widget();
+                                            }
+                                            else {
+                                                crypto_ticker_remove_widget();
+                                            }
+                                            crypto_ticker_save_config();
+                                            break;
+    }
+}
 
 
 static void crypto_ticker_textarea_event_cb( lv_obj_t * obj, lv_event_t event ) {

--- a/src/app/crypto_ticker/crypto_ticker_widget.cpp
+++ b/src/app/crypto_ticker/crypto_ticker_widget.cpp
@@ -114,7 +114,12 @@ void crypto_ticker_widget_sync_Task( void * pvParameters ) {
         uint32_t retval = crypto_ticker_fetch_price(crypto_ticker_get_config() , &crypto_ticker_widget_data );
         if ( retval == 200 ) {
             widget_set_indicator( crypto_ticker_widget, ICON_INDICATOR_OK );
-            widget_set_label( crypto_ticker_widget, crypto_ticker_widget_data.price );
+            // Check for label text width overflow
+            auto price = crypto_ticker_widget_data.price;
+            if (strlen(price) > 7 && strchr(price, '.') != NULL) {
+                price[7] = '\0'; // Trim it
+            }
+            widget_set_label( crypto_ticker_widget, price );
         }
         else {
             widget_set_indicator( crypto_ticker_widget, ICON_INDICATOR_FAIL );

--- a/src/app/crypto_ticker/crypto_ticker_widget.cpp
+++ b/src/app/crypto_ticker/crypto_ticker_widget.cpp
@@ -35,6 +35,7 @@
 #include "hardware/wifictl.h"
 
 EventGroupHandle_t crypto_ticker_widget_event_handle = NULL;
+
 TaskHandle_t _crypto_ticker_widget_sync_Task;
 void crypto_ticker_widget_sync_Task( void * pvParameters );
 
@@ -48,13 +49,12 @@ bool crypto_ticker_widget_wifictl_event_cb( EventBits_t event, void *arg );
 
 LV_IMG_DECLARE(bitcoin_64px);
 
-void crypto_ticker_widget_setup( void ) {
-    
+void crypto_ticker_add_widget( void ) {
     crypto_ticker_widget = widget_register( "BTC", &bitcoin_64px, enter_crypto_ticker_widget_event_cb );
+}
 
-    crypto_ticker_widget_event_handle = xEventGroupCreate();
-
-    wifictl_register_cb( WIFICTL_OFF | WIFICTL_CONNECT, crypto_ticker_widget_wifictl_event_cb, "crypto ticker widget" );
+void crypto_ticker_remove_widget( void ) {
+        crypto_ticker_widget = widget_remove( crypto_ticker_widget );
 }
 
 void crypto_ticker_hide_widget_icon_info( bool show ) {

--- a/src/app/crypto_ticker/crypto_ticker_widget.h
+++ b/src/app/crypto_ticker/crypto_ticker_widget.h
@@ -25,7 +25,7 @@
     #include <TTGO.h>
 
     #define CRYPTO_TICKER_WIDGET_SYNC_REQUEST    _BV(0)
-
+    extern EventGroupHandle_t crypto_ticker_widget_event_handle;
 
     typedef struct {
         bool valide = false;
@@ -33,9 +33,11 @@
         char price[50] = "";
     } crypto_ticker_widget_data_t;
 
-    void crypto_ticker_widget_setup( void );
+    void crypto_ticker_add_widget( void );
+    void crypto_ticker_remove_widget( void );
     void crypto_ticker_hide_widget_icon_info( bool show );
 
     void crypto_ticker_widget_sync_request( void );
+    bool crypto_ticker_widget_wifictl_event_cb( EventBits_t event, void *arg );
 
 #endif // CRYPTO_TICKER_WIDGET_H


### PR DESCRIPTION
1. Added option to switch CryptoTicker widget on and off without firmware rebuild
2. Trim cryptocurrency price in case of the widget label width overflow