### PR TITLE
Added long button press to return to main tile

### DIFF
--- a/src/hardware/pmu.cpp
+++ b/src/hardware/pmu.cpp
@@ -133,6 +133,11 @@ void pmu_loop( void ) {
             ttgo->power->clearIRQ();
             return;
         }
+        if ( ttgo->power->isPEKLongtPressIRQ() ) {
+            powermgm_set_event( POWERMGM_PMU_LONG_BUTTON );
+            ttgo->power->clearIRQ();
+            return;
+        }
         if ( ttgo->power->isTimerTimeoutIRQ() ) {
             powermgm_set_event( POWERMGM_SILENCE_WAKEUP_REQUEST );
             ttgo->power->clearTimerStatus();

--- a/src/hardware/powermgm.cpp
+++ b/src/hardware/powermgm.cpp
@@ -67,6 +67,12 @@ void powermgm_setup( void ) {
 }
 
 void powermgm_loop( void ) {
+    //Check if its a long press
+    if( powermgm_get_event( POWERMGM_PMU_LONG_BUTTON  ) ) {
+        motor_vibe(5);
+        mainbar_jump_to_maintile( LV_ANIM_OFF );
+        powermgm_clear_event( POWERMGM_PMU_LONG_BUTTON );
+    }
     // check if a button or doubleclick was release
     if( powermgm_get_event( POWERMGM_PMU_BUTTON | POWERMGM_BMA_DOUBLECLICK | POWERMGM_BMA_TILT | POWERMGM_RTC_ALARM ) ) {
         if ( powermgm_get_event( POWERMGM_STANDBY ) || powermgm_get_event( POWERMGM_SILENCE_WAKEUP ) ) {

--- a/src/hardware/powermgm.h
+++ b/src/hardware/powermgm.h
@@ -37,7 +37,7 @@
     #define POWERMGM_RTC_ALARM                  _BV(11)        /** @brief event mask for powermgm rtc alarm */
     #define POWERMGM_SHUTDOWN                   _BV(12)        /** @brief event mask for powermgm shutdown */
     #define POWERMGM_RESET                      _BV(13)        /** @brief event mask for powermgm reset */
-    #define POWERMGM_PMU_LONG_BUTTON            _BV(14)        /** @brief event mask for powermgm pmu button is pressed */
+    #define POWERMGM_PMU_LONG_BUTTON            _BV(14)        /** @brief event mask for powermgm pmu button is long pressed */
     
     /**
      * @brief setp power managment, coordinate managment beween CPU, wifictl, pmu, bma, display, backlight and lvgl

--- a/src/hardware/powermgm.h
+++ b/src/hardware/powermgm.h
@@ -37,6 +37,7 @@
     #define POWERMGM_RTC_ALARM                  _BV(11)        /** @brief event mask for powermgm rtc alarm */
     #define POWERMGM_SHUTDOWN                   _BV(12)        /** @brief event mask for powermgm shutdown */
     #define POWERMGM_RESET                      _BV(13)        /** @brief event mask for powermgm reset */
+    #define POWERMGM_PMU_LONG_BUTTON            _BV(14)        /** @brief event mask for powermgm pmu button is pressed */
     
     /**
      * @brief setp power managment, coordinate managment beween CPU, wifictl, pmu, bma, display, backlight and lvgl


### PR DESCRIPTION
Long press the power button, and it returns to the main screen.
Useful if you have enabled "block return maintile"