### PR TITLE
Historize animation

### DIFF
--- a/src/app/alarm_clock/alarm_clock_main.cpp
+++ b/src/app/alarm_clock/alarm_clock_main.cpp
@@ -174,7 +174,7 @@ static void enter_alarm_clock_setup_event_cb( lv_obj_t * obj, lv_event_t event )
 static void exit_alarm_clock_main_event_cb( lv_obj_t * obj, lv_event_t event ) {
     switch( event ) {
         case( LV_EVENT_CLICKED ):
-            mainbar_jump_back( LV_ANIM_OFF ); // user action (return back) will be performed first
+            mainbar_jump_back( ); // user action (return back) will be performed first
             break;
     }
 }

--- a/src/app/alarm_clock/alarm_clock_setup.cpp
+++ b/src/app/alarm_clock/alarm_clock_setup.cpp
@@ -53,7 +53,7 @@ void alarm_clock_setup_setup( uint32_t tile_num ) {
 static void exit_alarm_clock_setup_event_cb( lv_obj_t * obj, lv_event_t event ) {
     switch( event ) {
         case( LV_EVENT_CLICKED ):
-            mainbar_jump_back( LV_ANIM_ON );
+            mainbar_jump_back();
             break;
     }
 }

--- a/src/app/alarm_clock/alarm_in_progress.cpp
+++ b/src/app/alarm_clock/alarm_in_progress.cpp
@@ -115,7 +115,7 @@ static void alarm_task_function(lv_task_t * task){
     }
     else{
         display_set_brightness(brightness);
-        mainbar_jump_back( LV_ANIM_OFF );
+        mainbar_jump_back();
     }
 }
 

--- a/src/app/gps_status/gps_status_main.cpp
+++ b/src/app/gps_status/gps_status_main.cpp
@@ -245,7 +245,7 @@ static void enter_gps_status_setup_event_cb(lv_obj_t *obj, lv_event_t event) {
 static void exit_gps_status_main_event_cb(lv_obj_t *obj, lv_event_t event) {
     switch (event) {
         case (LV_EVENT_CLICKED):
-            mainbar_jump_back(LV_ANIM_OFF);
+            mainbar_jump_back();
             break;
     }
 }

--- a/src/app/gps_status/gps_status_setup.cpp
+++ b/src/app/gps_status/gps_status_setup.cpp
@@ -75,7 +75,7 @@ static void gps_status_foobar_switch_event_cb( lv_obj_t * obj, lv_event_t event 
 
 static void exit_gps_status_setup_event_cb( lv_obj_t * obj, lv_event_t event ) {
     switch( event ) {
-        case( LV_EVENT_CLICKED ):       mainbar_jump_back( LV_ANIM_ON );
+        case( LV_EVENT_CLICKED ):       mainbar_jump_back();
                                         break;
     }
 }

--- a/src/app/osmand/osmand_app_main.cpp
+++ b/src/app/osmand/osmand_app_main.cpp
@@ -167,7 +167,7 @@ void osmand_app_main_tile_time_update_task( lv_task_t * task ) {
 static void exit_osmand_app_main_event_cb( lv_obj_t * obj, lv_event_t event ) {
     switch( event ) {
         case( LV_EVENT_CLICKED ):   
-            mainbar_jump_back( LV_ANIM_OFF );
+            mainbar_jump_back();
             break;
     }
 }

--- a/src/app/osmmap/osmmap_app_main.cpp
+++ b/src/app/osmmap/osmmap_app_main.cpp
@@ -518,7 +518,7 @@ static void exit_osmmap_app_main_event_cb( lv_obj_t * obj, lv_event_t event ) {
             /**
              * exit to mainbar
              */
-            mainbar_jump_back( LV_ANIM_OFF );
+            mainbar_jump_back();
             break;
     }
 }

--- a/src/app/powermeter/powermeter_main.cpp
+++ b/src/app/powermeter/powermeter_main.cpp
@@ -235,7 +235,7 @@ static void enter_powermeter_setup_event_cb( lv_obj_t * obj, lv_event_t event ) 
 
 static void exit_powermeter_main_event_cb( lv_obj_t * obj, lv_event_t event ) {
     switch( event ) {
-        case( LV_EVENT_CLICKED ):       mainbar_jump_back( LV_ANIM_OFF );
+        case( LV_EVENT_CLICKED ):       mainbar_jump_back();
                                         break;
     }
 }

--- a/src/app/powermeter/powermeter_setup.cpp
+++ b/src/app/powermeter/powermeter_setup.cpp
@@ -203,7 +203,7 @@ static void exit_powermeter_widget_setup_event_cb( lv_obj_t * obj, lv_event_t ev
                                             strlcpy( powermeter_config->topic, lv_textarea_get_text( powermeter_topic_textfield ), sizeof( powermeter_config->topic ) );
                                             powermeter_config->port = atoi(lv_textarea_get_text( powermeter_port_textfield ));
                                             powermeter_save_config();                                            
-                                            mainbar_jump_back( LV_ANIM_ON );
+                                            mainbar_jump_back();
                                             break;
     }
 }

--- a/src/app/sailing/sailing_main.cpp
+++ b/src/app/sailing/sailing_main.cpp
@@ -260,7 +260,7 @@ static void enter_sailing_setup_event_cb( lv_obj_t * obj, lv_event_t event ) {
 
 static void exit_sailing_main_event_cb( lv_obj_t * obj, lv_event_t event ) {
     switch( event ) {
-        case( LV_EVENT_CLICKED ):       mainbar_jump_back( LV_ANIM_OFF );
+        case( LV_EVENT_CLICKED ):       mainbar_jump_back();
                                         display_set_timeout( 15 );
                                         break;
     }

--- a/src/app/sailing/sailing_setup.cpp
+++ b/src/app/sailing/sailing_setup.cpp
@@ -94,7 +94,7 @@ static void sailing_track_switch_event_cb( lv_obj_t * obj, lv_event_t event ) {
 
 static void exit_sailing_setup_event_cb( lv_obj_t * obj, lv_event_t event ) {
     switch( event ) {
-        case( LV_EVENT_CLICKED ):       mainbar_jump_back( LV_ANIM_ON );
+        case( LV_EVENT_CLICKED ):       mainbar_jump_back();
                                         statusbar_hide( false );
                                         break;
     }

--- a/src/app/sailing/sailing_setup.cpp
+++ b/src/app/sailing/sailing_setup.cpp
@@ -95,7 +95,6 @@ static void sailing_track_switch_event_cb( lv_obj_t * obj, lv_event_t event ) {
 static void exit_sailing_setup_event_cb( lv_obj_t * obj, lv_event_t event ) {
     switch( event ) {
         case( LV_EVENT_CLICKED ):       mainbar_jump_back();
-                                        statusbar_hide( false );
                                         break;
     }
 }

--- a/src/app/stopwatch/stopwatch_app_main.cpp
+++ b/src/app/stopwatch/stopwatch_app_main.cpp
@@ -170,7 +170,7 @@ static void reset_stopwatch_app_main_event_cb( lv_obj_t * obj, lv_event_t event 
 
 static void exit_stopwatch_app_main_event_cb( lv_obj_t * obj, lv_event_t event ) {
     switch( event ) {
-        case( LV_EVENT_CLICKED ):       mainbar_jump_back( LV_ANIM_OFF );
+        case( LV_EVENT_CLICKED ):       mainbar_jump_back();
                                         break;
     }
 }

--- a/src/app/weather/weather_forecast.cpp
+++ b/src/app/weather/weather_forecast.cpp
@@ -139,7 +139,7 @@ bool weather_forecast_wifictl_event_cb( EventBits_t event, void *arg ) {
 
 static void exit_weather_widget_event_cb( lv_obj_t * obj, lv_event_t event ) {
     switch( event ) {
-        case( LV_EVENT_CLICKED ):       mainbar_jump_back( LV_ANIM_OFF );
+        case( LV_EVENT_CLICKED ):       mainbar_jump_back();
                                         break;
     }
 }

--- a/src/app/weather/weather_setup.cpp
+++ b/src/app/weather/weather_setup.cpp
@@ -260,7 +260,7 @@ static void exit_weather_widget_setup_event_cb( lv_obj_t * obj, lv_event_t event
                                             strlcpy( weather_config->lat, lv_textarea_get_text( weather_lat_textfield ), sizeof( weather_config->lat ) );
                                             strlcpy( weather_config->lon, lv_textarea_get_text( weather_lon_textfield ), sizeof( weather_config->lon ) );
                                             weather_save_config();
-                                            mainbar_jump_back( LV_ANIM_OFF );
+                                            mainbar_jump_back();
                                             break;
     }
 }

--- a/src/gui/mainbar/mainbar.cpp
+++ b/src/gui/mainbar/mainbar.cpp
@@ -80,7 +80,7 @@ void mainbar_setup( void ) {
     mainbar_clear_history();
 }
 
-void mainbar_add_current_tile_to_history( void ) {
+void mainbar_add_current_tile_to_history( lv_anim_enable_t anim ) {
     lv_coord_t x,y;
     /*
      * check if mainbar already initialized
@@ -100,7 +100,8 @@ void mainbar_add_current_tile_to_history( void ) {
             mainbar_history.tile[ mainbar_history.entrys ].x = x;
             mainbar_history.tile[ mainbar_history.entrys ].y = y;
             mainbar_history.statusbar[ mainbar_history.entrys ] = statusbar_get_hidden_state();
-            MAINBAR_INFO_LOG("store tile to history: %d, %d, %d", x, y, statusbar_get_hidden_state() );
+            mainbar_history.anim[ mainbar_history.entrys ] = anim;
+            MAINBAR_INFO_LOG("store tile to history: %d, %d, %d, %d", x, y, statusbar_get_hidden_state(), anim );
         }
     }
 }
@@ -121,7 +122,7 @@ void mainbar_clear_history( void ) {
     MAINBAR_INFO_LOG("clear mainbar history");
 }
 
-void mainbar_jump_back( lv_anim_enable_t anim ) {
+void mainbar_jump_back( void ) {
     lv_coord_t x,y;
     /*
      * check if mainbar already initialized
@@ -140,7 +141,7 @@ void mainbar_jump_back( lv_anim_enable_t anim ) {
          * jump back
          */
         MAINBAR_INFO_LOG("jump back to tile: %d, %d, %d", mainbar_history.tile[ mainbar_history.entrys ].x, mainbar_history.tile[ mainbar_history.entrys ].y, mainbar_history.statusbar[ mainbar_history.entrys ] );
-        lv_tileview_set_tile_act( mainbar, mainbar_history.tile[ mainbar_history.entrys ].x, mainbar_history.tile[ mainbar_history.entrys ].y, anim );
+        lv_tileview_set_tile_act( mainbar, mainbar_history.tile[ mainbar_history.entrys ].x, mainbar_history.tile[ mainbar_history.entrys ].y, mainbar_history.anim[ mainbar_history.entrys ] );
         statusbar_hide( mainbar_history.statusbar[ mainbar_history.entrys ] );
         gui_force_redraw( true );
         /**
@@ -397,7 +398,7 @@ void mainbar_jump_to_tilenumber( uint32_t tile_number, lv_anim_enable_t anim, bo
          * store current tile and statusbar state
          */
         if ( tile_number != current_tile ) {
-            mainbar_add_current_tile_to_history();
+            mainbar_add_current_tile_to_history( anim );
         }
         statusbar_hide( statusbar );
         /**
@@ -453,7 +454,7 @@ void mainbar_jump_to_tilenumber( uint32_t tile_number, lv_anim_enable_t anim ) {
          * store current tile and statusbar state
          */
         if ( tile_number != current_tile ) {
-            mainbar_add_current_tile_to_history();
+            mainbar_add_current_tile_to_history( anim );
         }
         /**
          * jump into tile

--- a/src/gui/mainbar/mainbar.cpp
+++ b/src/gui/mainbar/mainbar.cpp
@@ -77,10 +77,7 @@ void mainbar_setup( void ) {
     powermgm_register_cb( POWERMGM_STANDBY | POWERMGM_WAKEUP | POWERMGM_SILENCE_WAKEUP, mainbar_powermgm_event_cb, "mainbar powermgm" );
     rtcctl_register_cb( RTCCTL_ALARM_OCCURRED, mainbar_rtcctl_event_cb, "mainbar rtcctl" );
 
-    mainbar_history.entrys = 0;
-    mainbar_history.tile[ 0 ].x = 0;
-    mainbar_history.tile[ 0 ].y = 0;
-    mainbar_history.statusbar[ 0 ] = true;
+    mainbar_clear_history();
 }
 
 void mainbar_add_current_tile_to_history( void ) {
@@ -120,6 +117,7 @@ void mainbar_clear_history( void ) {
     mainbar_history.entrys = 0;
     mainbar_history.tile[ 0 ].x = 0;
     mainbar_history.tile[ 0 ].y = 0;
+    mainbar_history.statusbar[ 0 ] = true;
     MAINBAR_INFO_LOG("clear mainbar history");
 }
 

--- a/src/gui/mainbar/mainbar.h
+++ b/src/gui/mainbar/mainbar.h
@@ -35,9 +35,10 @@
     #define STATUSBAR_SHOW              false
 
     typedef struct {
-        uint32_t    entrys;
-        lv_point_t  tile[ MAINBAR_MAX_HISTORY ];
-        bool        statusbar[ MAINBAR_MAX_HISTORY ];
+        uint32_t         entrys;
+        lv_point_t       tile[ MAINBAR_MAX_HISTORY ];
+        bool             statusbar[ MAINBAR_MAX_HISTORY ];
+        lv_anim_enable_t anim[ MAINBAR_MAX_HISTORY ];
     } mainbar_history_t;
 
     typedef struct {
@@ -137,6 +138,6 @@
     /**
      * jump back in tile history
      */
-    void mainbar_jump_back( lv_anim_enable_t anim );
+    void mainbar_jump_back( void );
 
 #endif // _MAINBAR_H

--- a/src/gui/mainbar/setup_tile/bluetooth_settings/bluetooth_settings.cpp
+++ b/src/gui/mainbar/setup_tile/bluetooth_settings/bluetooth_settings.cpp
@@ -134,7 +134,7 @@ static void enter_bluetooth_setup_event_cb( lv_obj_t * obj, lv_event_t event ) {
 
 static void exit_bluetooth_setup_event_cb( lv_obj_t * obj, lv_event_t event ) {
     switch( event ) {
-        case( LV_EVENT_CLICKED ):       mainbar_jump_back( LV_ANIM_OFF );
+        case( LV_EVENT_CLICKED ):       mainbar_jump_back();
                                         break;
     }
 }

--- a/src/gui/mainbar/setup_tile/display_settings/display_setting.cpp
+++ b/src/gui/mainbar/setup_tile/display_settings/display_setting.cpp
@@ -267,7 +267,7 @@ static void down_display_setup_event_cb( lv_obj_t * obj, lv_event_t event ) {
 
 static void up_display_setup_event_cb( lv_obj_t * obj, lv_event_t event ) {
     switch( event ) {
-        case( LV_EVENT_CLICKED ):       mainbar_jump_back( LV_ANIM_ON );
+        case( LV_EVENT_CLICKED ):       mainbar_jump_back();
                                         break;
     }
 
@@ -275,7 +275,7 @@ static void up_display_setup_event_cb( lv_obj_t * obj, lv_event_t event ) {
 
 static void exit_display_setup_event_cb( lv_obj_t * obj, lv_event_t event ) {
     switch( event ) {
-        case( LV_EVENT_CLICKED ):       mainbar_jump_back( LV_ANIM_OFF );
+        case( LV_EVENT_CLICKED ):       mainbar_jump_back();
                                         display_save_config();
                                         break;
     }

--- a/src/gui/mainbar/setup_tile/move_settings/move_settings.cpp
+++ b/src/gui/mainbar/setup_tile/move_settings/move_settings.cpp
@@ -86,7 +86,7 @@ static void enter_move_setup_event_cb( lv_obj_t * obj, lv_event_t event ) {
 
 static void exit_move_setup_event_cb( lv_obj_t * obj, lv_event_t event ) {
     switch( event ) {
-        case( LV_EVENT_CLICKED ):       mainbar_jump_back( LV_ANIM_OFF );
+        case( LV_EVENT_CLICKED ):       mainbar_jump_back();
                                         break;
     }
 }

--- a/src/gui/mainbar/setup_tile/sdcard_settings/sdcard_settings.cpp
+++ b/src/gui/mainbar/setup_tile/sdcard_settings/sdcard_settings.cpp
@@ -145,7 +145,7 @@ static void enter_sdcard_settings_event_cb(lv_obj_t *obj, lv_event_t event) {
 static void exit_sdcard_settings_event_cb(lv_obj_t *obj, lv_event_t event) {
     switch (event) {
         case (LV_EVENT_CLICKED):
-            mainbar_jump_back( LV_ANIM_OFF );
+            mainbar_jump_back();
             break;
     }
 }

--- a/src/gui/mainbar/setup_tile/sound_settings/sound_settings.cpp
+++ b/src/gui/mainbar/setup_tile/sound_settings/sound_settings.cpp
@@ -154,7 +154,7 @@ static void enter_sound_setup_event_cb( lv_obj_t * obj, lv_event_t event ) {
 
 static void exit_sound_setup_event_cb( lv_obj_t * obj, lv_event_t event ) {
     switch( event ) {
-        case( LV_EVENT_CLICKED ):       mainbar_jump_back( LV_ANIM_OFF );
+        case( LV_EVENT_CLICKED ):       mainbar_jump_back();
                                         sound_save_config();
                                         break;
     }

--- a/src/gui/mainbar/setup_tile/time_settings/time_settings.cpp
+++ b/src/gui/mainbar/setup_tile/time_settings/time_settings.cpp
@@ -299,7 +299,7 @@ static void enter_time_setup_event_cb( lv_obj_t * obj, lv_event_t event ) {
 static void exit_time_setup_event_cb( lv_obj_t * obj, lv_event_t event ) {
     switch( event ) {
         case( LV_EVENT_CLICKED ):       time_settings_set_timezone_timerule();
-                                        mainbar_jump_back( LV_ANIM_OFF );
+                                        mainbar_jump_back();
                                         break;
     }
 }

--- a/src/gui/mainbar/setup_tile/update/update.cpp
+++ b/src/gui/mainbar/setup_tile/update/update.cpp
@@ -215,7 +215,7 @@ static void enter_update_setup_event_cb( lv_obj_t * obj, lv_event_t event ) {
 static void exit_update_setup_event_cb( lv_obj_t * obj, lv_event_t event ) {
     switch( event ) {
         case( LV_EVENT_CLICKED ):       
-            mainbar_jump_back( LV_ANIM_OFF );
+            mainbar_jump_back();
             break;
     }
 }

--- a/src/gui/mainbar/setup_tile/update/update_setup.cpp
+++ b/src/gui/mainbar/setup_tile/update/update_setup.cpp
@@ -120,7 +120,7 @@ static void update_check_autosync_onoff_event_handler( lv_obj_t * obj, lv_event_
 
 static void exit_update_check_setup_event_cb( lv_obj_t * obj, lv_event_t event ) {
     switch( event ) {
-        case( LV_EVENT_CLICKED ):           mainbar_jump_back( false );
+        case( LV_EVENT_CLICKED ):           mainbar_jump_back();
                                             strlcpy( update_config->updateurl , lv_textarea_get_text( update_check_url_textfield ), sizeof( update_config->updateurl ) );
                                             update_save_config();
                                             break;

--- a/src/gui/mainbar/setup_tile/utilities/utilities.cpp
+++ b/src/gui/mainbar/setup_tile/utilities/utilities.cpp
@@ -187,7 +187,7 @@ static void enter_utilities_event_cb( lv_obj_t * obj, lv_event_t event ) {
 
 static void exit_utilities_event_cb( lv_obj_t * obj, lv_event_t event ) {
     switch( event ) {
-        case( LV_EVENT_CLICKED ):       mainbar_jump_back( LV_ANIM_OFF );
+        case( LV_EVENT_CLICKED ):       mainbar_jump_back();
                                         break;
     }
 }

--- a/src/gui/mainbar/setup_tile/watchface/watchface_manager_app.cpp
+++ b/src/gui/mainbar/setup_tile/watchface/watchface_manager_app.cpp
@@ -238,7 +238,7 @@ void watchface_manager_theme_install_task( lv_task_t * task ) {
 static void exit_watchface_manager_app_event_cb(  lv_obj_t * obj, lv_event_t event ) {
     switch ( event ) {
         case LV_EVENT_CLICKED:
-            mainbar_jump_back( LV_ANIM_OFF );
+            mainbar_jump_back();
             break;
     }
 }

--- a/src/gui/mainbar/setup_tile/watchface/watchface_setup.cpp
+++ b/src/gui/mainbar/setup_tile/watchface/watchface_setup.cpp
@@ -182,7 +182,7 @@ static void exit_watchface_setup_event_cb( lv_obj_t * obj, lv_event_t event ) {
             /**
              * exit to mainbar
              */
-            mainbar_jump_back( LV_ANIM_OFF );
+            mainbar_jump_back();
             break;
     }
 }

--- a/src/gui/mainbar/setup_tile/watchface/watchface_tile.cpp
+++ b/src/gui/mainbar/setup_tile/watchface/watchface_tile.cpp
@@ -276,7 +276,7 @@ void watchface_reload_and_test( void ) {
 
 static void exit_watchface_app_tile_event_cb( lv_obj_t * obj, lv_event_t event ) {
     switch( event ) {
-        case( LV_EVENT_SHORT_CLICKED ): mainbar_jump_back( LV_ANIM_OFF );
+        case( LV_EVENT_SHORT_CLICKED ): mainbar_jump_back();
                                         break;
         case( LV_EVENT_LONG_PRESSED ):  mainbar_jump_to_tilenumber( watchface_manager_get_setup_tile_num(), LV_ANIM_OFF );
                                         break;

--- a/src/gui/mainbar/setup_tile/wlan_settings/wlan_settings.cpp
+++ b/src/gui/mainbar/setup_tile/wlan_settings/wlan_settings.cpp
@@ -160,7 +160,7 @@ static void enter_wifi_settings_event_cb( lv_obj_t * obj, lv_event_t event ) {
 
 static void exit_wifi_settings_event_cb( lv_obj_t * obj, lv_event_t event ) {
     switch( event ) {
-        case( LV_EVENT_CLICKED ):       mainbar_jump_back( LV_ANIM_OFF );
+        case( LV_EVENT_CLICKED ):       mainbar_jump_back();
                                         break;
     }
 }
@@ -250,7 +250,7 @@ static void wlan_password_event_cb( lv_obj_t * obj, lv_event_t event ) {
 static void exit_wifi_password_event_cb( lv_obj_t * obj, lv_event_t event ) {
     switch( event ) {
         case( LV_EVENT_CLICKED ):       keyboard_hide();
-                                        mainbar_jump_back( LV_ANIM_ON );
+                                        mainbar_jump_back();
                                         break;
     }
 }
@@ -329,7 +329,7 @@ static void enter_wifi_setup_event_cb( lv_obj_t * obj, lv_event_t event ) {
 
 static void exit_wifi_setup_event_cb( lv_obj_t * obj, lv_event_t event ) {
     switch( event ) {
-        case( LV_EVENT_CLICKED ):       mainbar_jump_back( LV_ANIM_ON );
+        case( LV_EVENT_CLICKED ):       mainbar_jump_back();
                                         break;
     }
 }


### PR DESCRIPTION
Technically, removing animation parameter from exit callbacks will allow to factorize all these codes without loosing consistency for the user.