### PR TITLE
User expressions to control the behavior of the watchface

### DIFF
--- a/WATCHFACE.md
+++ b/WATCHFACE.md
@@ -86,7 +86,7 @@ A label entry looks like this:
 ```
 |option|value type|description|
 |--|--|--|
-|`enable`|bool|true or false
+|`enable`|bool|`true`, `false` or expression
 |`type`|string|see label types
 |`label`|string|label string
 |`font`|string|font name or a font filename. the font filename ends with `.font`. see font types and size.
@@ -157,7 +157,7 @@ A image entry looks like this:
 ```
 |option|value type|description|
 |--|--|--|
-|`enable`|bool|true or false
+|`enable`|bool|`true`, `false` or expression
 |`type`|string|see image types
 |`file`|string|image filename. Example: `"klingon_red.png"` loads a png from spiffs on location `/spiffs/watchface/klingon_red.png`.
 |`hide_interval`|int|0 mean not used. positive values hide this label in a show/hide interval. negative values in a hide/show interval.
@@ -180,3 +180,48 @@ A image entry looks like this:
 |`time_min`|`rotation_range` divide by current min and add to `rotation_start`. min range is 0-59|
 |`time_sec`|`rotation_range` divide by current min and add to `rotation_start`. hour range is 0-59|
 
+# Expressions
+
+Some mathematical or logical expressions can be use to control display of the watchface elements.
+Full syntax is available at [TinyExpr main site](https://github.com/codeplea/tinyexpr).
+
+## Variables
+
+Variables available in this context are described in the following table.
+
+| Name               | Description |
+|--------------------|-------------|
+| gps                | GPS status (disabled=0, enabled(no fix)=1, enabled+fix=2) |
+| ble                | Bluetooth status (disabled=0, enabled+disconnected=1, enabled+connected=2) |
+| sound_volume       | Sound volume |
+| sound_enabled      | Sound enable = 1, else 0 |
+| alarm              | Alarm (No alarm = 0, Alarm set = 1) |
+| wifi               | Wifi status (disabled=0, enabled+disconnected=1, enabled+connected=2) |
+| battery_percent    | Battery percent (range is 0-100) |
+| battery_voltage    | Battery voltage (voltage range is 0-5) |
+| bluetooth_messages | Number of messages (`bluetooth_messages()`) |
+| steps              | Number of steps (`steps()`) |
+| time_hour          | Hour of the current time |
+| time_min           | Minutes of the current time |
+| time_sec           | Seconds of the current time |
+
+Note: expressions are computed in double.
+
+## Examples
+
+Display GPS symbol when GPS is enabled.
+```
+    {
+      "enable": "gps > 0",
+      "type": "text",
+      "label": "\uF124",
+      "font": "Montserrat",
+      "font_color": "#6c680d",
+      "align": "center",
+      "font_size": 16,
+      "x_offset": 206,
+      "y_offset": 20,
+      "x_size": 24,
+      "y_size": 20
+    },
+```

--- a/WATCHFACE.md
+++ b/WATCHFACE.md
@@ -1,5 +1,8 @@
 # watchface.tar.gz
-This compressed file containts all file as a package to downoad and run a watchface. all image and fontfiles must are included here. a minimum watchface.tar.gz included a watchface_theme.json. from here all fancy things begins.
+This compressed file contains all file as a package to download and run a watchface.
+All image and fontfiles must be included here.
+A minimum `watchface.tar.gz` includes a `watchface_theme.json`.
+From here all fancy things begins.
 
 # watchface_theme.json overview
 file format
@@ -22,10 +25,10 @@ file format
 ```
 # dial, hour, min, sec, hour_shadow, min_shadow and sec_shadow
 
-A dial, hour and so on has the fowllowing three options:
+A dial, hour and so on has the following three options:
 
 `enable`:		true or false
-`x_offset`:		x postion on the screen in pixel. Top is 0.
+`x_offset`:		x position on the screen in pixel. Top is 0.
 `y_offset`:		y position on the screen in pixel. Left is 0.
 
 Remember, a center to the screen and the rotation center is in the middle of the image.
@@ -42,7 +45,7 @@ Remember, a center to the screen and the rotation center is in the middle of the
 },
 ...
 ```
-The image name convention is `watchface_dial.png`, `watchface_hour.png` and so on and will automaticly loaded if enabled. No entry mean disabled.
+The image name convention is `watchface_dial.png`, `watchface_hour.png` and so on and will automatically loaded if enabled. No entry mean disabled.
 
 # label
 A label entry looks like this:
@@ -90,8 +93,8 @@ A label entry looks like this:
 |`font_color`|string|font color like "#808080" for pue grey, format is "#rrggbb" in hex
 |`font_size`|string|font size in pixel, see font types and size
 |`align`|string|`center`, `left` and `right`
-|`hide_interval`|int|0 mean not used. positive values hide this label in a show/hide intveral. and negative values is hide/show.
-|`x_offset`|int|x postion on the screen in pixel. Top is 0.
+|`hide_interval`|int|0 mean not used. positive values hide this label in a show/hide interval. and negative values is hide/show.
+|`x_offset`|int|x position on the screen in pixel. Top is 0.
 |`y_offset`|int|y position on the screen in pixel. Left is 0.
 |`x_size`|int|x container size on the screen in pixel.
 |`y_size`|int|y container size on the screen in pixel.
@@ -157,12 +160,12 @@ A image entry looks like this:
 |`enable`|bool|true or false
 |`type`|string|see image types
 |`file`|string|image filename. Example: `"klingon_red.png"` loads a png from spiffs on location `/spiffs/watchface/klingon_red.png`.
-|`hide_interval`|int|0 mean not used. positive values hide this label in a show/hide intveral. negative values in a hide/show interval.
-|`rotaion_range`|int|ratation range in degree.
-|`rotaion_start`|int|ratation start angle in degree.
+|`hide_interval`|int|0 mean not used. positive values hide this label in a show/hide interval. negative values in a hide/show interval.
+|`rotation_range`|int|rotation range in degree.
+|`rotation_start`|int|rotation start angle in degree.
 |`rotation_x_origin`|int|x origin for rotation center in pixel. top is 0.
 |`rotation_y_origin`|int|y origin for rotation center in pixel. left is 0.
-|`x_offset`|int|x postion on the screen in pixel. Top is 0.
+|`x_offset`|int|x position on the screen in pixel. Top is 0.
 |`y_offset`|int|y position on the screen in pixel. Left is 0.
 |`x_size`|int|x container size on the screen in pixel.
 |`y_size`|int|y container size on the screen in pixel.
@@ -171,9 +174,9 @@ A image entry looks like this:
 |image type|discription|
 |--|--|
 |`image`|a raw image without interaction.|
-|`battery_percent`|`rotaion_range` divide by battery percent and add to `rotaion_start`, battery range is 0-100.|
-|`battery_voltage`|`rotaion_range` divide by battery voltage and add to `rotaion_start`. voltage range is 0-5.|
-|`time_hour`|`rotaion_range` divide by current hour and add to `rotaion_start`. hour range is 0-23|
-|`time_min`|`rotaion_range` divide by current min and add to `rotaion_start`. min range is 0-59|
-|`time_sec`|`rotaion_range` divide by current min and add to `rotaion_start`. hour range is 0-59|
+|`battery_percent`|`rotation_range` divide by battery percent and add to `rotation_start`, battery range is 0-100.|
+|`battery_voltage`|`rotation_range` divide by battery voltage and add to `rotation_start`. voltage range is 0-5.|
+|`time_hour`|`rotation_range` divide by current hour and add to `rotation_start`. hour range is 0-23|
+|`time_min`|`rotation_range` divide by current min and add to `rotation_start`. min range is 0-59|
+|`time_sec`|`rotation_range` divide by current min and add to `rotation_start`. hour range is 0-59|
 

--- a/WATCHFACE.md
+++ b/WATCHFACE.md
@@ -84,7 +84,7 @@ A label entry looks like this:
 	}
 ]
 ```
-|option|value type|discription|
+|option|value type|description|
 |--|--|--|
 |`enable`|bool|true or false
 |`type`|string|see label types
@@ -104,7 +104,7 @@ The example above schow how a blinking time works.
 ## label types
 
 
-|label type|discription|
+|label type|description|
 |--|--|
 |`text`|a raw text.|
 |`date`|an information related to date/time. See `strftime` function for format.|
@@ -155,7 +155,7 @@ A image entry looks like this:
 	}
 ]
 ```
-|option|value type|discription|
+|option|value type|description|
 |--|--|--|
 |`enable`|bool|true or false
 |`type`|string|see image types
@@ -171,7 +171,7 @@ A image entry looks like this:
 |`y_size`|int|y container size on the screen in pixel.
 
 ## image types
-|image type|discription|
+|image type|description|
 |--|--|
 |`image`|a raw image without interaction.|
 |`battery_percent`|`rotation_range` divide by battery percent and add to `rotation_start`, battery range is 0-100.|

--- a/src/gui/mainbar/setup_tile/bluetooth_settings/bluetooth_message.h
+++ b/src/gui/mainbar/setup_tile/bluetooth_settings/bluetooth_message.h
@@ -23,6 +23,7 @@
     #define _BLUETOOTH_MESSAGE_H
 
     #include <TTGO.h>
+    #include "lvgl/lvgl.h"
 
     struct src_icon_t {
         const char src_name[ 24 ];

--- a/src/gui/mainbar/setup_tile/watchface/config/watchface_expr.cpp
+++ b/src/gui/mainbar/setup_tile/watchface/config/watchface_expr.cpp
@@ -1,0 +1,71 @@
+
+/*
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
+
+#include "watchface_expr.h"
+#include "hardware/pmu.h"
+#include "hardware/bma.h"
+#include "gui/mainbar/setup_tile/bluetooth_settings/bluetooth_message.h"
+#include "time.h"
+
+static double time_hour;
+static double time_min;
+static double time_sec;
+
+extern "C" {
+    /**
+     * Adapter functions.
+     * 
+     * TinyExpr expect function returning double.
+     */
+
+    double get_battery_percent(void) {
+        return pmu_get_battery_percent();
+    }
+    double get_battery_voltage(void) {
+        return pmu_get_battery_voltage() / 1000;
+    }
+    double get_bluetooth_nb_msg(void) {
+        return bluetooth_get_number_of_msg();
+    }
+    double get_stepcounter(void) {
+        return bma_get_stepcounter();
+    }
+}
+
+te_variable watchface_expr_vars[] = {
+    {"battery_percent", (const void*)get_battery_percent, TE_FUNCTION0},
+    {"battery_voltage", (const void*)get_battery_voltage, TE_FUNCTION0},
+    {"bluetooth_messages", (const void*)get_bluetooth_nb_msg, TE_FUNCTION0},
+    {"steps", (const void*)get_stepcounter, TE_FUNCTION0},
+    {"time_hour", &time_hour},
+    {"time_min", &time_min},
+    {"time_sec", &time_sec}
+};
+
+void watchface_expr_update( tm &new_info ) {
+    time_hour = new_info.tm_hour;
+    time_min = new_info.tm_min;
+    time_sec = new_info.tm_sec;
+}
+
+te_expr * watchface_expr_compile(const char* str, int *error) {
+    return te_compile(str, watchface_expr_vars, sizeof(watchface_expr_vars), error);
+}
+
+double watchface_expr_eval( te_expr *expr) {
+    return te_eval( expr );
+}

--- a/src/gui/mainbar/setup_tile/watchface/config/watchface_expr.cpp
+++ b/src/gui/mainbar/setup_tile/watchface/config/watchface_expr.cpp
@@ -15,15 +15,45 @@
  *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
  */
 
+/*
+ * Some design elements.
+ * The module offers acces to all the parts of the state of the watch (battery level, steps, wifi...).
+ * The communication with watchface is in a pull driven model: the watchface regularly refresh its state
+ * requesting current values from the watch state model.
+ * Thus, for some part of the watch state model, data are immediately requested with a direct function call (steps, batt level),
+ * while for other part, with a lower refresh rate, the state is cached (wifi status...).
+ */
+
 #include "watchface_expr.h"
 #include "hardware/pmu.h"
 #include "hardware/bma.h"
+#include "hardware/gpsctl.h"
+#include "hardware/wifictl.h"
+#include "hardware/blectl.h"
+#include "hardware/rtcctl.h"
+#include "hardware/sound.h"
 #include "gui/mainbar/setup_tile/bluetooth_settings/bluetooth_message.h"
 #include "time.h"
 
 static double time_hour;
 static double time_min;
 static double time_sec;
+
+// Sound
+static double sound_volume = 0.;
+static double sound_enabled = 0.;
+
+// Wifi
+static double wifi = 0; // disabled=0, enabled+disconnected=1, enabled+connected=2
+
+// Bluetooth
+static double ble = 0.; // disabled=0, enabled+disconnected=1, enabled+connected=2
+
+// GPS
+static double gps = 0.; // disabled=0, enabled(no fix)=1, enabled+fix=2
+
+// Alarm
+static double alarm_state = 0.;
 
 extern "C" {
     /**
@@ -47,6 +77,12 @@ extern "C" {
 }
 
 te_variable watchface_expr_vars[] = {
+    {"gps", &gps},
+    {"ble", &ble},
+    {"sound_volume", &sound_volume},
+    {"sound_enabled", &sound_enabled},
+    {"alarm", &alarm_state},
+    {"wifi", &wifi},
     {"battery_percent", (const void*)get_battery_percent, TE_FUNCTION0},
     {"battery_voltage", (const void*)get_battery_voltage, TE_FUNCTION0},
     {"bluetooth_messages", (const void*)get_bluetooth_nb_msg, TE_FUNCTION0},
@@ -68,4 +104,90 @@ te_expr * watchface_expr_compile(const char* str, int *error) {
 
 double watchface_expr_eval( te_expr *expr) {
     return te_eval( expr );
+}
+
+bool watchface_expr_gpsctl_event_cb( EventBits_t event, void *arg ) {
+    switch( event ) {
+        case GPSCTL_DISABLE:
+            gps = 0.;
+            break;
+        case GPSCTL_ENABLE:
+            gps = 1.;
+            break;
+        case GPSCTL_FIX:
+            gps = 2.;
+            break;
+        case GPSCTL_NOFIX:
+            gps = 1.;
+            break;
+    }
+    return( true );
+}
+
+bool watchface_expr_soundctl_event_cb( EventBits_t event, void *arg ) {
+    switch( event ) {
+        case SOUNDCTL_ENABLED:
+            sound_enabled = *(bool*)arg;
+            break;
+        case SOUNDCTL_VOLUME:
+            sound_volume = *(uint8_t*)arg;
+            break;
+    }
+    return( true );
+}
+
+bool watchface_expr_rtcctl_event_cb( EventBits_t event, void *arg ) {
+    switch( event ) {
+        case RTCCTL_ALARM_ENABLED:
+            alarm_state = 1.;
+            break;
+        case RTCCTL_ALARM_DISABLED:
+            alarm_state = 0.;
+            break;
+    }
+    return( true );
+}
+
+bool watchface_expr_blectl_event_cb( EventBits_t event, void *arg ) {
+    switch( event ) {
+        case BLECTL_ON:
+            ble = 1.;
+            break;
+        case BLECTL_OFF:
+            ble = 0.;
+            break;
+        case BLECTL_CONNECT:
+            ble = 2.;
+            break;
+        case BLECTL_DISCONNECT:
+            ble = 1.;
+            break;
+    }
+    return( true );
+}
+
+bool watchface_expr_wifictl_event_cb( EventBits_t event, void *arg ) {
+    switch( event ) {
+        case WIFICTL_CONNECT:
+            wifi = 2.;
+            break;
+        case WIFICTL_DISCONNECT:
+            wifi = 1.;
+            break;
+        case WIFICTL_OFF:
+            wifi = 0.;
+            break;
+        case WIFICTL_ON:
+            wifi = 1.;
+            break;
+    }
+    return( true );
+}
+
+void watchface_expr_setup( void ) {
+    blectl_register_cb( BLECTL_CONNECT | BLECTL_DISCONNECT | BLECTL_ON | BLECTL_OFF, watchface_expr_blectl_event_cb, "bluetooth state" );
+    wifictl_register_cb( WIFICTL_CONNECT | WIFICTL_DISCONNECT | WIFICTL_OFF | WIFICTL_ON, watchface_expr_wifictl_event_cb, "wifi state" );
+    rtcctl_register_cb( RTCCTL_ALARM_ENABLED | RTCCTL_ALARM_DISABLED, watchface_expr_rtcctl_event_cb, "rtc state" );
+    sound_register_cb( SOUNDCTL_ENABLED | SOUNDCTL_VOLUME, watchface_expr_soundctl_event_cb, "sound state");
+    gpsctl_register_cb( GPSCTL_DISABLE | GPSCTL_ENABLE | GPSCTL_FIX | GPSCTL_NOFIX, watchface_expr_gpsctl_event_cb, "gps state" );
 }

--- a/src/gui/mainbar/setup_tile/watchface/config/watchface_expr.h
+++ b/src/gui/mainbar/setup_tile/watchface/config/watchface_expr.h
@@ -40,4 +40,9 @@ te_expr * watchface_expr_compile(const char* str, int *error);
  */
 double watchface_expr_eval( te_expr *expr);
 
+/**
+ * @brief setup the watchface expression module
+ */
+void watchface_expr_setup( void );
+
 #endif // _WATCHFACE_EXPR_H

--- a/src/gui/mainbar/setup_tile/watchface/config/watchface_expr.h
+++ b/src/gui/mainbar/setup_tile/watchface/config/watchface_expr.h
@@ -1,0 +1,43 @@
+
+/*
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+ */
+#ifndef _WATCHFACE_EXPR_H
+#define _WATCHFACE_EXPR_H
+
+#include "utils/tinyexpr/tinyexpr.h"
+#include "time.h"
+
+/**
+ * Available variables
+ */
+extern te_variable watchface_expr_vars[];
+
+/**
+ * @brief Update values of global context
+ */
+void watchface_expr_update( tm &new_info );
+
+/**
+ * @brief compile the expression for later evaluation
+ */
+te_expr * watchface_expr_compile(const char* str, int *error);
+
+/**
+ * @brief evaluate a precompiled expression
+ */
+double watchface_expr_eval( te_expr *expr);
+
+#endif // _WATCHFACE_EXPR_H

--- a/src/gui/mainbar/setup_tile/watchface/config/watchface_theme_config.cpp
+++ b/src/gui/mainbar/setup_tile/watchface/config/watchface_theme_config.cpp
@@ -70,7 +70,7 @@ bool watchface_theme_config_t::onSave(JsonDocument& doc ) {
 
     for( int i = 0 ; i < WATCHFACE_LABEL_NUM ; i++ ) {
         if ( dial.label[ i ].enable ) {
-            doc["label"][ labelcount ]["enable"] = dial.label[ i ].enable;
+            doc["label"][ labelcount ]["enable"] = dial.label[ i ].enable_expr;
             doc["label"][ labelcount ]["type"] = dial.label[ i ].type;
             doc["label"][ labelcount ]["expr"] = dial.label[ i ].raw_expr;
             doc["label"][ labelcount ]["label"] = dial.label[ i ].label;
@@ -142,17 +142,30 @@ bool watchface_theme_config_t::onLoad(JsonDocument& doc) {
     dial.sec_shadow.x_offset = doc["sec_shadow"]["x_offset"] | 5;
     dial.sec_shadow.y_offset = doc["sec_shadow"]["y_offset"] | 5;
 
+    int err;
+
     for( int i = 0 ; i < WATCHFACE_LABEL_NUM ; i++ ) {
-        dial.label[ i ].enable = doc["label"][i]["enable"] | false;
+        te_free( dial.label[ i ].enable );
+        dial.label[ i ].enable = NULL;
+        if ( doc["label"][i].containsKey("enable") ) {
+            if ( doc["label"][i]["enable"].is<bool>() ) {
+                const char *val = doc["label"][i]["enable"] ? "1.0" : "0.0";
+                log_i( "Enable : %s", val );
+                strncpy( dial.label[ i ].enable_expr, val, sizeof( dial.label[ i ].enable_expr ) );
+            } else {
+                strncpy( dial.label[ i ].enable_expr, doc["label"][i]["enable"], sizeof( dial.label[ i ].enable_expr ) );
+            }
+            dial.label[ i ].enable = watchface_expr_compile( dial.label[ i ].enable_expr, &err );
+            if ( dial.label[ i ].enable == NULL ) {
+                log_e("Parse error in '%s' at %d", doc["label"][i]["enable"], err);
+            }
+        }
         strncpy( dial.label[ i ].type, doc["label"][i]["type"] | "text", sizeof( dial.label[ i ].type ) );
         te_free( dial.label[ i ].expr );
         if ( doc["label"][i].containsKey("expr") && strlen(doc["label"][i]["expr"]) > 0 ) {
             // Parse expression
-            int err;
-            te_expr *expr = watchface_expr_compile(doc["label"][i]["expr"], &err);
-            if (expr) {
-                dial.label[ i ].expr = expr;
-            } else {
+            dial.label[ i ].expr = watchface_expr_compile(doc["label"][i]["expr"], &err);
+            if ( dial.label[ i ].expr == NULL ) {
                 log_e("Parse error in '%s' at %d", doc["label"][i]["expr"], err);
             }
         } else {
@@ -229,7 +242,8 @@ bool watchface_theme_config_t::onDefault( void ) {
      * clear all labels
      */
     for( int i = 0 ; i < WATCHFACE_LABEL_NUM ; i++ ) {
-        dial.label[ i ].enable = false;
+        dial.label[ i ].enable = NULL;
+        strncpy( dial.label[ i ].enable_expr, "", sizeof( dial.label[ i ].enable_expr ) );
         dial.label[ i ].expr = NULL;
         strncpy( dial.label[ i ].type, "text", sizeof( dial.label[ i ].type ) );
         strncpy( dial.label[ i ].raw_expr, "", sizeof( dial.label[ i ].raw_expr ) );
@@ -265,7 +279,8 @@ bool watchface_theme_config_t::onDefault( void ) {
     /**
      * setup default date label
      */
-    dial.label[ 0 ].enable = true;
+    dial.label[ 0 ].enable = NULL;
+    strncpy( dial.label[ 0 ].enable_expr, "", sizeof( dial.label[ 0 ].enable_expr ) );
     strncpy( dial.label[ 0 ].type, "date", sizeof( dial.label[ 0 ].type ) );
     strncpy( dial.label[ 0 ].label, "%d.%b", sizeof( dial.label[ 0 ].label ) );
     strncpy( dial.label[ 0 ].font, "Ubuntu" , sizeof( dial.label[ 0 ].font ) );

--- a/src/gui/mainbar/setup_tile/watchface/config/watchface_theme_config.h
+++ b/src/gui/mainbar/setup_tile/watchface/config/watchface_theme_config.h
@@ -25,6 +25,7 @@
     #include <TTGO.h>
     #include "config.h"
     #include "utils/basejsonconfig.h"
+    #include "utils/tinyexpr/tinyexpr.h"
 
     #define WATCHFACE_LABEL_NUM                 20
     #define WATCHFACE_IMAGE_NUM                 20
@@ -65,6 +66,8 @@
     typedef struct {
         bool enable = true;                             /** @brief enable the label */
         char type[32] = "";                             /** @brief type of the label */
+        char raw_expr[128] = "";                        /** @brief raw expression */
+        te_expr *expr = NULL;                           /** @brief expression value of the label */
         char label[32] = "";                            /** @brief text for the label */
         char font[32] = "";                             /** @brief font name */
         int32_t font_size = 0;                          /** @brief font size: 12,16,32,48 and 72 */

--- a/src/gui/mainbar/setup_tile/watchface/config/watchface_theme_config.h
+++ b/src/gui/mainbar/setup_tile/watchface/config/watchface_theme_config.h
@@ -42,6 +42,8 @@
     #define WATCHFACE_MIN_SHADOW_IMAGE_FILE     "/spiffs/watchface/watchface_min_s.png"
     #define WATCHFACE_SEC_SHADOW_IMAGE_FILE     "/spiffs/watchface/watchface_sec_s.png"
 
+    #define WATCHFACE_EXPR_MAX_SIZE             128
+
     /**
      * @brief dial image control structure
      */
@@ -64,9 +66,10 @@
      * @brief label control structure
      */
     typedef struct {
-        bool enable = true;                             /** @brief enable the label */
+        te_expr *enable = NULL;                         /** @brief enable the label */
+        char enable_expr[WATCHFACE_EXPR_MAX_SIZE] = ""; /** @brief expression for enable flag */
         char type[32] = "";                             /** @brief type of the label */
-        char raw_expr[128] = "";                        /** @brief raw expression */
+        char raw_expr[WATCHFACE_EXPR_MAX_SIZE] = "";    /** @brief raw expression */
         te_expr *expr = NULL;                           /** @brief expression value of the label */
         char label[32] = "";                            /** @brief text for the label */
         char font[32] = "";                             /** @brief font name */

--- a/src/gui/mainbar/setup_tile/watchface/config/watchface_theme_config.h
+++ b/src/gui/mainbar/setup_tile/watchface/config/watchface_theme_config.h
@@ -62,13 +62,20 @@
         int32_t x_offset = 0;                           /** @brief x offset of the image relative to the center */
         int32_t y_offset = 0;                           /** @brief x offset of the image relative to the center */
     } watchface_index_t;
+    typedef struct {
+        te_expr *enable = NULL;                         /** @brief enable the widget */
+        char enable_expr[WATCHFACE_EXPR_MAX_SIZE] = ""; /** @brief expression for enable flag */
+        char type[32] = "";                             /** @brief type of the widget */
+        int32_t hide_interval = 0;
+        int32_t x_offset = 0;                           /** @brief x offset for the widget*/
+        int32_t y_offset = 0;                           /** @brief y offset for the widget*/
+        int32_t x_size = 0;                             /** @brief x size for the widget*/
+        int32_t y_size = 0;                             /** @brief y size for the widget*/
+    } watchface_widget_t;
     /**
      * @brief label control structure
      */
-    typedef struct {
-        te_expr *enable = NULL;                         /** @brief enable the label */
-        char enable_expr[WATCHFACE_EXPR_MAX_SIZE] = ""; /** @brief expression for enable flag */
-        char type[32] = "";                             /** @brief type of the label */
+    typedef struct : watchface_widget_t {
         char raw_expr[WATCHFACE_EXPR_MAX_SIZE] = "";    /** @brief raw expression */
         te_expr *expr = NULL;                           /** @brief expression value of the label */
         char label[32] = "";                            /** @brief text for the label */
@@ -76,29 +83,17 @@
         int32_t font_size = 0;                          /** @brief font size: 12,16,32,48 and 72 */
         char font_color[32] = "";                       /** @brief label color in format '#000000' */
         char align[32] = "";                            /** @brief align the label, default is 'center' */
-        int32_t hide_interval = 0;
-        int32_t x_offset = 0;                           /** @brief x offset for the label*/
-        int32_t y_offset = 0;                           /** @brief y offset for the label*/
-        int32_t x_size = 0;                             /** @brief x size for the label*/
-        int32_t y_size = 0;                             /** @brief y size for the label*/
     } watchface_label_t;
     /**
      * @brief label control structure
      */
-    typedef struct {
-        bool enable = true;                             /** @brief enable the label */
-        char type[32] = "";                             /** @brief type of the image */
+    typedef struct : watchface_widget_t {
         char file[32] = "";                             /** @brief filename of the image */
         int32_t stages = 0;
         int32_t rotation_range = 0;                     /** @brief number of vertical stages */
         int32_t rotation_start = 0;                     /** @brief number of vertical stages */
         int32_t rotation_x_origin = 0;
         int32_t rotation_y_origin = 0;
-        int32_t hide_interval = 0;
-        int32_t x_offset = 0;                           /** @brief x offset for the image*/
-        int32_t y_offset = 0;                           /** @brief y offset for the image*/
-        int32_t x_size = 0;                             /** @brief x size for the image*/
-        int32_t y_size = 0;                             /** @brief y size for the image*/
     } watchface_image_t;
     /**
      * @brief watchface theme control structure

--- a/src/gui/mainbar/setup_tile/watchface/watchface_tile.cpp
+++ b/src/gui/mainbar/setup_tile/watchface/watchface_tile.cpp
@@ -170,7 +170,7 @@ void watchface_tile_setup( void ) {
         lv_obj_set_width( watchface_label_cont, watchface_theme_config.dial.label[ i ].x_size );
         lv_obj_set_height( watchface_label_cont, watchface_theme_config.dial.label[ i ].y_size );
         lv_obj_set_pos( watchface_label_cont, watchface_theme_config.dial.label[ i ].x_offset, watchface_theme_config.dial.label[ i ].y_offset );
-        lv_obj_set_hidden( watchface_label_cont, !watchface_theme_config.dial.label[ i ].enable );
+        lv_obj_set_hidden( watchface_label_cont, !(watchface_theme_config.dial.label[ i ].enable != NULL && watchface_expr_eval( watchface_theme_config.dial.label[ i ].enable)) );
         lv_obj_add_style( watchface_label_cont, LV_OBJ_PART_MAIN, &watchface_app_tile_style );
         /**
          * alloc and setup label
@@ -519,7 +519,7 @@ void watchface_reload_theme( void ) {
         lv_obj_set_width( lv_obj_get_parent( watchface_label[ i ] ), watchface_theme_config.dial.label[ i ].x_size );
         lv_obj_set_height( lv_obj_get_parent( watchface_label[ i ] ), watchface_theme_config.dial.label[ i ].y_size );
         lv_obj_set_pos( lv_obj_get_parent( watchface_label[ i ] ), watchface_theme_config.dial.label[ i ].x_offset, watchface_theme_config.dial.label[ i ].y_offset );
-        lv_obj_set_hidden( lv_obj_get_parent( watchface_label[ i ] ), !watchface_theme_config.dial.label[ i ].enable );
+        lv_obj_set_hidden( lv_obj_get_parent( watchface_label[ i ] ), !(watchface_theme_config.dial.label[ i ].enable != NULL && watchface_expr_eval( watchface_theme_config.dial.label[ i ].enable)) );
         lv_obj_add_style( lv_obj_get_parent( watchface_label[ i ] ), LV_OBJ_PART_MAIN, &watchface_app_tile_style );
         /**
          * alloc and setup label
@@ -898,7 +898,7 @@ void watchface_app_label_update( tm &info ) {
         /**
          * check if label enabled
          */
-        if ( watchface_theme_config.dial.label[ i ].enable ) {
+        if ( watchface_theme_config.dial.label[ i ].enable != NULL && watchface_expr_eval( watchface_theme_config.dial.label[ i ].enable ) ) {
             /**
              * check label type
              */

--- a/src/gui/mainbar/setup_tile/watchface/watchface_tile.cpp
+++ b/src/gui/mainbar/setup_tile/watchface/watchface_tile.cpp
@@ -116,8 +116,8 @@ void watchface_remove_theme_files ( void );
 lv_font_t *watchface_get_font( const char *font, int32_t font_size );
 lv_color_t watchface_get_color( char *color );
 lv_align_t watchface_get_align( char *align );
-void watchface_app_label_update( void );
-void watchface_app_image_update( void );
+void watchface_app_label_update( tm &info );
+void watchface_app_image_update( tm &info );
 
 void watchface_tile_setup( void ) {
     watchface_app_tile_num = mainbar_add_app_tile( 1, 1, "WatchFace Tile" );
@@ -813,17 +813,12 @@ void watchface_app_tile_update( void ) {
         lv_img_set_angle( watchface_min_s_img, Angle_M );
         lv_img_set_angle( watchface_sec_s_img, Angle_S );
 
-        watchface_app_label_update();
-        watchface_app_image_update();
+        watchface_app_label_update( info );
+        watchface_app_image_update( info );
     }
 }
 
-void watchface_app_image_update( void ) {
-    tm info;
-    time_t now;
-    time(&now);
-    localtime_r( &now, &info );
-
+void watchface_app_image_update( tm &info ) {
     for( int i = 0 ; i < WATCHFACE_IMAGE_NUM ; i++ ) {
         /**
          * check if label enabled
@@ -893,12 +888,7 @@ void watchface_app_image_update( void ) {
     }
 }
 
-void watchface_app_label_update( void ) {
-    tm info;
-    time_t now;
-    time(&now);
-    localtime_r( &now, &info );
-
+void watchface_app_label_update( tm &info ) {
     for( int i = 0 ; i < WATCHFACE_LABEL_NUM ; i++ ) {
         char temp_str[ 64 ] = "";
         /**

--- a/src/gui/mainbar/setup_tile/watchface/watchface_tile.cpp
+++ b/src/gui/mainbar/setup_tile/watchface/watchface_tile.cpp
@@ -27,6 +27,7 @@
 #include "watchface_manager.h"
 #include "watchface_tile.h"
 #include "watchface_setup.h"
+#include "gui/mainbar/setup_tile/watchface/config/watchface_expr.h"
 #include "gui/mainbar/setup_tile/watchface/config/watchface_theme_config.h"
 #include "gui/mainbar/setup_tile/watchface/config/watchface_config.h"
 #include "gui/gui.h"
@@ -793,6 +794,9 @@ void watchface_app_tile_update( void ) {
         time(&now);
         localtime_r( &now, &info );
 
+        // Update global context
+        watchface_expr_update( info );
+
         //Angle calculation for Hands
         int Angle_S = (int)((info.tm_sec % 60) * 60 );
         int Angle_M = (int)((info.tm_min % 60) * 60 ) + ( watchface_theme_config.dial.min.smooth ? (int)(info.tm_sec % 60) : 0 );
@@ -915,6 +919,10 @@ void watchface_app_label_update( tm &info ) {
             }
             else if ( !strcmp( "steps", watchface_theme_config.dial.label[ i ].type ) ) {
                 snprintf( temp_str, sizeof( temp_str ), watchface_theme_config.dial.label[ i ].label, bma_get_stepcounter() );
+            }
+            else if ( !strcmp( "expr", watchface_theme_config.dial.label[ i ].type ) && watchface_theme_config.dial.label[ i ].expr != NULL ) {
+                double val = watchface_expr_eval(watchface_theme_config.dial.label[ i ].expr);
+                snprintf( temp_str, sizeof( temp_str ), watchface_theme_config.dial.label[ i ].label, val );
             }
             else {
                 snprintf( temp_str, sizeof( temp_str ), "n/a" );

--- a/src/gui/mainbar/setup_tile/watchface/watchface_tile.cpp
+++ b/src/gui/mainbar/setup_tile/watchface/watchface_tile.cpp
@@ -195,7 +195,7 @@ void watchface_tile_setup( void ) {
         lv_obj_set_width( watchface_image_cont, watchface_theme_config.dial.image[ i ].x_size );
         lv_obj_set_height( watchface_image_cont, watchface_theme_config.dial.image[ i ].y_size );
         lv_obj_set_pos( watchface_image_cont, watchface_theme_config.dial.image[ i ].x_offset, watchface_theme_config.dial.image[ i ].y_offset );
-        lv_obj_set_hidden( watchface_image_cont, !watchface_theme_config.dial.image[ i ].enable );
+        lv_obj_set_hidden( watchface_image_cont, !(watchface_theme_config.dial.image[ i ].enable != NULL && watchface_expr_eval( watchface_theme_config.dial.image[ i ].enable)) );
         lv_obj_add_style( watchface_image_cont, LV_OBJ_PART_MAIN, &watchface_app_image_style );
         /**
          * alloc and setup image
@@ -539,7 +539,7 @@ void watchface_reload_theme( void ) {
         lv_obj_set_width( lv_obj_get_parent( watchface_image[ i ] ), watchface_theme_config.dial.image[ i ].x_size );
         lv_obj_set_height( lv_obj_get_parent( watchface_image[ i ] ), watchface_theme_config.dial.image[ i ].y_size );
         lv_obj_set_pos( lv_obj_get_parent( watchface_image[ i ] ), watchface_theme_config.dial.image[ i ].x_offset, watchface_theme_config.dial.image[ i ].y_offset );
-        lv_obj_set_hidden( lv_obj_get_parent( watchface_image[ i ] ), !watchface_theme_config.dial.image[ i ].enable );
+        lv_obj_set_hidden( lv_obj_get_parent( watchface_image[ i ] ), !(watchface_theme_config.dial.image[ i ].enable != NULL && watchface_expr_eval( watchface_theme_config.dial.image[ i ].enable)) );
         /**
          * alloc and setup image
          */
@@ -827,7 +827,7 @@ void watchface_app_image_update( tm &info ) {
         /**
          * check if label enabled
          */
-        if ( watchface_theme_config.dial.image[ i ].enable ) {
+        if ( watchface_theme_config.dial.image[ i ].enable != NULL && watchface_expr_eval( watchface_theme_config.dial.image[ i ].enable ) ) {
             int32_t angle = 0;
             /**
              * check label type

--- a/src/my-ttgo-watch.ino
+++ b/src/my-ttgo-watch.ino
@@ -27,6 +27,8 @@
 
 #include "gui/gui.h"
 
+#include "gui/mainbar/setup_tile/watchface/config/watchface_expr.h"
+
 #include "hardware/hardware.h"
 #include "hardware/powermgm.h"
 
@@ -79,6 +81,8 @@ void setup() {
     fxrates_app_setup();
     powermeter_app_setup();
 	FindPhone_setup();
+
+    watchface_expr_setup();
     /**
      * post hardware setup
      * 

--- a/src/utils/tinyexpr/LICENSE
+++ b/src/utils/tinyexpr/LICENSE
@@ -1,0 +1,19 @@
+zlib License
+
+Copyright (C) 2015, 2016 Lewis Van Winkle
+
+This software is provided 'as-is', without any express or implied
+warranty. In no event will the authors be held liable for any damages
+arising from the use of this software.
+
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it
+freely, subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must not
+   claim that you wrote the original software. If you use this software
+   in a product, an acknowledgement in the product documentation would be
+   appreciated but is not required.
+2. Altered source versions must be plainly marked as such, and must not be
+   misrepresented as being the original software.
+3. This notice may not be removed or altered from any source distribution.

--- a/src/utils/tinyexpr/README
+++ b/src/utils/tinyexpr/README
@@ -1,0 +1,1 @@
+Cf. https://github.com/codeplea/tinyexpr/tree/logic

--- a/src/utils/tinyexpr/tinyexpr.c
+++ b/src/utils/tinyexpr/tinyexpr.c
@@ -1,0 +1,772 @@
+/*
+ * TINYEXPR - Tiny recursive descent parser and evaluation engine in C
+ *
+ * Copyright (c) 2015-2018 Lewis Van Winkle
+ *
+ * http://CodePlea.com
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ * claim that you wrote the original software. If you use this software
+ * in a product, an acknowledgement in the product documentation would be
+ * appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+/* COMPILE TIME OPTIONS */
+
+/* Exponentiation associativity:
+For a^b^c = (a^b)^c and -a^b = (-a)^b do nothing.
+For a^b^c = a^(b^c) and -a^b = -(a^b) uncomment the next line.*/
+/* #define TE_POW_FROM_RIGHT */
+
+/* Logarithms
+For log = base 10 log do nothing
+For log = natural log uncomment the next line. */
+/* #define TE_NAT_LOG */
+
+#include "tinyexpr.h"
+#include <stdlib.h>
+#include <math.h>
+#include <string.h>
+#include <stdio.h>
+#include <limits.h>
+
+#ifndef NAN
+#define NAN (0.0/0.0)
+#endif
+
+#ifndef INFINITY
+#define INFINITY (1.0/0.0)
+#endif
+
+
+typedef double (*te_fun2)(double, double);
+
+enum {
+    TOK_NULL = TE_CLOSURE7+1, TOK_ERROR, TOK_END, TOK_SEP,
+    TOK_OPEN, TOK_CLOSE, TOK_NUMBER, TOK_VARIABLE, TOK_INFIX
+};
+
+
+enum {TE_CONSTANT = 1};
+
+
+typedef struct state {
+    const char *start;
+    const char *next;
+    int type;
+    union {double value; const double *bound; const void *function;};
+    void *context;
+
+    const te_variable *lookup;
+    int lookup_len;
+} state;
+
+
+#define TYPE_MASK(TYPE) ((TYPE)&0x0000001F)
+
+#define IS_PURE(TYPE) (((TYPE) & TE_FLAG_PURE) != 0)
+#define IS_FUNCTION(TYPE) (((TYPE) & TE_FUNCTION0) != 0)
+#define IS_CLOSURE(TYPE) (((TYPE) & TE_CLOSURE0) != 0)
+#define ARITY(TYPE) ( ((TYPE) & (TE_FUNCTION0 | TE_CLOSURE0)) ? ((TYPE) & 0x00000007) : 0 )
+#define NEW_EXPR(type, ...) new_expr((type), (const te_expr*[]){__VA_ARGS__})
+
+static te_expr *new_expr(const int type, const te_expr *parameters[]) {
+    const int arity = ARITY(type);
+    const int psize = sizeof(void*) * arity;
+    const int size = (sizeof(te_expr) - sizeof(void*)) + psize + (IS_CLOSURE(type) ? sizeof(void*) : 0);
+    te_expr *ret = malloc(size);
+    memset(ret, 0, size);
+    if (arity && parameters) {
+        memcpy(ret->parameters, parameters, psize);
+    }
+    ret->type = type;
+    ret->bound = 0;
+    return ret;
+}
+
+
+void te_free_parameters(te_expr *n) {
+    if (!n) return;
+    switch (TYPE_MASK(n->type)) {
+        case TE_FUNCTION7: case TE_CLOSURE7: te_free(n->parameters[6]);     /* Falls through. */
+        case TE_FUNCTION6: case TE_CLOSURE6: te_free(n->parameters[5]);     /* Falls through. */
+        case TE_FUNCTION5: case TE_CLOSURE5: te_free(n->parameters[4]);     /* Falls through. */
+        case TE_FUNCTION4: case TE_CLOSURE4: te_free(n->parameters[3]);     /* Falls through. */
+        case TE_FUNCTION3: case TE_CLOSURE3: te_free(n->parameters[2]);     /* Falls through. */
+        case TE_FUNCTION2: case TE_CLOSURE2: te_free(n->parameters[1]);     /* Falls through. */
+        case TE_FUNCTION1: case TE_CLOSURE1: te_free(n->parameters[0]);
+    }
+}
+
+
+void te_free(te_expr *n) {
+    if (!n) return;
+    te_free_parameters(n);
+    free(n);
+}
+
+
+static double pi(void) {return 3.14159265358979323846;}
+static double e(void) {return 2.71828182845904523536;}
+static double fac(double a) {/* simplest version of fac */
+    if (a < 0.0)
+        return NAN;
+    if (a > UINT_MAX)
+        return INFINITY;
+    unsigned int ua = (unsigned int)(a);
+    unsigned long int result = 1, i;
+    for (i = 1; i <= ua; i++) {
+        if (i > ULONG_MAX / result)
+            return INFINITY;
+        result *= i;
+    }
+    return (double)result;
+}
+static double ncr(double n, double r) {
+    if (n < 0.0 || r < 0.0 || n < r) return NAN;
+    if (n > UINT_MAX || r > UINT_MAX) return INFINITY;
+    unsigned long int un = (unsigned int)(n), ur = (unsigned int)(r), i;
+    unsigned long int result = 1;
+    if (ur > un / 2) ur = un - ur;
+    for (i = 1; i <= ur; i++) {
+        if (result > ULONG_MAX / (un - ur + i))
+            return INFINITY;
+        result *= un - ur + i;
+        result /= i;
+    }
+    return result;
+}
+static double npr(double n, double r) {return ncr(n, r) * fac(r);}
+
+static const te_variable functions[] = {
+    /* must be in alphabetical order */
+    {"abs", fabs,     TE_FUNCTION1 | TE_FLAG_PURE, 0},
+    {"acos", acos,    TE_FUNCTION1 | TE_FLAG_PURE, 0},
+    {"asin", asin,    TE_FUNCTION1 | TE_FLAG_PURE, 0},
+    {"atan", atan,    TE_FUNCTION1 | TE_FLAG_PURE, 0},
+    {"atan2", atan2,  TE_FUNCTION2 | TE_FLAG_PURE, 0},
+    {"ceil", ceil,    TE_FUNCTION1 | TE_FLAG_PURE, 0},
+    {"cos", cos,      TE_FUNCTION1 | TE_FLAG_PURE, 0},
+    {"cosh", cosh,    TE_FUNCTION1 | TE_FLAG_PURE, 0},
+    {"e", e,          TE_FUNCTION0 | TE_FLAG_PURE, 0},
+    {"exp", exp,      TE_FUNCTION1 | TE_FLAG_PURE, 0},
+    {"fac", fac,      TE_FUNCTION1 | TE_FLAG_PURE, 0},
+    {"floor", floor,  TE_FUNCTION1 | TE_FLAG_PURE, 0},
+    {"ln", log,       TE_FUNCTION1 | TE_FLAG_PURE, 0},
+#ifdef TE_NAT_LOG
+    {"log", log,      TE_FUNCTION1 | TE_FLAG_PURE, 0},
+#else
+    {"log", log10,    TE_FUNCTION1 | TE_FLAG_PURE, 0},
+#endif
+    {"log10", log10,  TE_FUNCTION1 | TE_FLAG_PURE, 0},
+    {"ncr", ncr,      TE_FUNCTION2 | TE_FLAG_PURE, 0},
+    {"npr", npr,      TE_FUNCTION2 | TE_FLAG_PURE, 0},
+    {"pi", pi,        TE_FUNCTION0 | TE_FLAG_PURE, 0},
+    {"pow", pow,      TE_FUNCTION2 | TE_FLAG_PURE, 0},
+    {"sin", sin,      TE_FUNCTION1 | TE_FLAG_PURE, 0},
+    {"sinh", sinh,    TE_FUNCTION1 | TE_FLAG_PURE, 0},
+    {"sqrt", sqrt,    TE_FUNCTION1 | TE_FLAG_PURE, 0},
+    {"tan", tan,      TE_FUNCTION1 | TE_FLAG_PURE, 0},
+    {"tanh", tanh,    TE_FUNCTION1 | TE_FLAG_PURE, 0},
+    {0, 0, 0, 0}
+};
+
+static const te_variable *find_builtin(const char *name, int len) {
+    int imin = 0;
+    int imax = sizeof(functions) / sizeof(te_variable) - 2;
+
+    /*Binary search.*/
+    while (imax >= imin) {
+        const int i = (imin + ((imax-imin)/2));
+        int c = strncmp(name, functions[i].name, len);
+        if (!c) c = '\0' - functions[i].name[len];
+        if (c == 0) {
+            return functions + i;
+        } else if (c > 0) {
+            imin = i + 1;
+        } else {
+            imax = i - 1;
+        }
+    }
+
+    return 0;
+}
+
+static const te_variable *find_lookup(const state *s, const char *name, int len) {
+    int iters;
+    const te_variable *var;
+    if (!s->lookup) return 0;
+
+    for (var = s->lookup, iters = s->lookup_len; iters; ++var, --iters) {
+        if (strncmp(name, var->name, len) == 0 && var->name[len] == '\0') {
+            return var;
+        }
+    }
+    return 0;
+}
+
+
+
+static double add(double a, double b) {return a + b;}
+static double sub(double a, double b) {return a - b;}
+static double mul(double a, double b) {return a * b;}
+static double divide(double a, double b) {return a / b;}
+static double negate(double a) {return -a;}
+static double comma(double a, double b) {(void)a; return b;}
+
+static double greater(double a, double b) {return a > b;}
+static double greater_eq(double a, double b) {return a >= b;}
+static double lower(double a, double b) {return a < b;}
+static double lower_eq(double a, double b) {return a <= b;}
+static double equal(double a, double b) {return a == b;}
+static double not_equal(double a, double b) {return a != b;}
+static double logical_and(double a, double b) {return a != 0.0 && b != 0.0;}
+static double logical_or(double a, double b) {return a != 0.0 || b != 0.0;}
+static double logical_not(double a) {return a == 0.0;}
+static double logical_notnot(double a) {return a != 0.0;}
+static double negate_logical_not(double a) {return -(a == 0.0);}
+static double negate_logical_notnot(double a) {return -(a != 0.0);}
+
+
+void next_token(state *s) {
+    s->type = TOK_NULL;
+
+    do {
+
+        if (!*s->next){
+            s->type = TOK_END;
+            return;
+        }
+
+        /* Try reading a number. */
+        if ((s->next[0] >= '0' && s->next[0] <= '9') || s->next[0] == '.') {
+            s->value = strtod(s->next, (char**)&s->next);
+            s->type = TOK_NUMBER;
+        } else {
+            /* Look for a variable or builtin function call. */
+            if (s->next[0] >= 'a' && s->next[0] <= 'z') {
+                const char *start;
+                start = s->next;
+                while ((s->next[0] >= 'a' && s->next[0] <= 'z') || (s->next[0] >= '0' && s->next[0] <= '9') || (s->next[0] == '_')) s->next++;
+
+                const te_variable *var = find_lookup(s, start, s->next - start);
+                if (!var) var = find_builtin(start, s->next - start);
+
+                if (!var) {
+                    s->type = TOK_ERROR;
+                } else {
+                    switch(TYPE_MASK(var->type))
+                    {
+                        case TE_VARIABLE:
+                            s->type = TOK_VARIABLE;
+                            s->bound = var->address;
+                            break;
+
+                        case TE_CLOSURE0: case TE_CLOSURE1: case TE_CLOSURE2: case TE_CLOSURE3:         /* Falls through. */
+                        case TE_CLOSURE4: case TE_CLOSURE5: case TE_CLOSURE6: case TE_CLOSURE7:         /* Falls through. */
+                            s->context = var->context;                                                  /* Falls through. */
+
+                        case TE_FUNCTION0: case TE_FUNCTION1: case TE_FUNCTION2: case TE_FUNCTION3:     /* Falls through. */
+                        case TE_FUNCTION4: case TE_FUNCTION5: case TE_FUNCTION6: case TE_FUNCTION7:     /* Falls through. */
+                            s->type = var->type;
+                            s->function = var->address;
+                            break;
+                    }
+                }
+
+            } else {
+                /* Look for an operator or special character. */
+                switch (s->next++[0]) {
+                    case '+': s->type = TOK_INFIX; s->function = add; break;
+                    case '-': s->type = TOK_INFIX; s->function = sub; break;
+                    case '*': s->type = TOK_INFIX; s->function = mul; break;
+                    case '/': s->type = TOK_INFIX; s->function = divide; break;
+                    case '^': s->type = TOK_INFIX; s->function = pow; break;
+                    case '%': s->type = TOK_INFIX; s->function = fmod; break;
+                    case '!':
+                        if (s->next++[0] == '=') {
+                            s->type = TOK_INFIX; s->function = not_equal;
+                        } else {
+                            s->next--;
+                            s->type = TOK_INFIX; s->function = logical_not;
+                        }
+                        break;
+                    case '=':
+                        if (s->next++[0] == '=') {
+                            s->type = TOK_INFIX; s->function = equal;
+                        } else {
+                            s->type = TOK_ERROR;
+                        }
+                        break;
+                    case '<':
+                        if (s->next++[0] == '=') {
+                            s->type = TOK_INFIX; s->function = lower_eq;
+                        } else {
+                            s->next--;
+                            s->type = TOK_INFIX; s->function = lower;
+                        }
+                        break;
+                    case '>':
+                        if (s->next++[0] == '=') {
+                            s->type = TOK_INFIX; s->function = greater_eq;
+                        } else {
+                            s->next--;
+                            s->type = TOK_INFIX; s->function = greater;
+                        }
+                        break;
+                    case '&':
+                        if (s->next++[0] == '&') {
+                            s->type = TOK_INFIX; s->function = logical_and;
+                        } else {
+                            s->type = TOK_ERROR;
+                        }
+                        break;
+                    case '|':
+                        if (s->next++[0] == '|') {
+                            s->type = TOK_INFIX; s->function = logical_or;
+                        } else {
+                            s->type = TOK_ERROR;
+                        }
+                        break;
+                    case '(': s->type = TOK_OPEN; break;
+                    case ')': s->type = TOK_CLOSE; break;
+                    case ',': s->type = TOK_SEP; break;
+                    case ' ': case '\t': case '\n': case '\r': break;
+                    default: s->type = TOK_ERROR; break;
+                }
+            }
+        }
+    } while (s->type == TOK_NULL);
+}
+
+
+static te_expr *list(state *s);
+static te_expr *expr(state *s);
+static te_expr *power(state *s);
+
+static te_expr *base(state *s) {
+    /* <base>      =    <constant> | <variable> | <function-0> {"(" ")"} | <function-1> <power> | <function-X> "(" <expr> {"," <expr>} ")" | "(" <list> ")" */
+    te_expr *ret;
+    int arity;
+
+    switch (TYPE_MASK(s->type)) {
+        case TOK_NUMBER:
+            ret = new_expr(TE_CONSTANT, 0);
+            ret->value = s->value;
+            next_token(s);
+            break;
+
+        case TOK_VARIABLE:
+            ret = new_expr(TE_VARIABLE, 0);
+            ret->bound = s->bound;
+            next_token(s);
+            break;
+
+        case TE_FUNCTION0:
+        case TE_CLOSURE0:
+            ret = new_expr(s->type, 0);
+            ret->function = s->function;
+            if (IS_CLOSURE(s->type)) ret->parameters[0] = s->context;
+            next_token(s);
+            if (s->type == TOK_OPEN) {
+                next_token(s);
+                if (s->type != TOK_CLOSE) {
+                    s->type = TOK_ERROR;
+                } else {
+                    next_token(s);
+                }
+            }
+            break;
+
+        case TE_FUNCTION1:
+        case TE_CLOSURE1:
+            ret = new_expr(s->type, 0);
+            ret->function = s->function;
+            if (IS_CLOSURE(s->type)) ret->parameters[1] = s->context;
+            next_token(s);
+            ret->parameters[0] = power(s);
+            break;
+
+        case TE_FUNCTION2: case TE_FUNCTION3: case TE_FUNCTION4:
+        case TE_FUNCTION5: case TE_FUNCTION6: case TE_FUNCTION7:
+        case TE_CLOSURE2: case TE_CLOSURE3: case TE_CLOSURE4:
+        case TE_CLOSURE5: case TE_CLOSURE6: case TE_CLOSURE7:
+            arity = ARITY(s->type);
+
+            ret = new_expr(s->type, 0);
+            ret->function = s->function;
+            if (IS_CLOSURE(s->type)) ret->parameters[arity] = s->context;
+            next_token(s);
+
+            if (s->type != TOK_OPEN) {
+                s->type = TOK_ERROR;
+            } else {
+                int i;
+                for(i = 0; i < arity; i++) {
+                    next_token(s);
+                    ret->parameters[i] = expr(s);
+                    if(s->type != TOK_SEP) {
+                        break;
+                    }
+                }
+                if(s->type != TOK_CLOSE || i != arity - 1) {
+                    s->type = TOK_ERROR;
+                } else {
+                    next_token(s);
+                }
+            }
+
+            break;
+
+        case TOK_OPEN:
+            next_token(s);
+            ret = list(s);
+            if (s->type != TOK_CLOSE) {
+                s->type = TOK_ERROR;
+            } else {
+                next_token(s);
+            }
+            break;
+
+        default:
+            ret = new_expr(0, 0);
+            s->type = TOK_ERROR;
+            ret->value = NAN;
+            break;
+    }
+
+    return ret;
+}
+
+
+static te_expr *power(state *s) {
+    /* <power>     =    {("-" | "+" | "!")} <base> */
+    int sign = 1;
+    while (s->type == TOK_INFIX && (s->function == add || s->function == sub)) {
+        if (s->function == sub) sign = -sign;
+        next_token(s);
+    }
+
+    int logical = 0;
+    while (s->type == TOK_INFIX && (s->function == add || s->function == sub || s->function == logical_not)) {
+        if (s->function == logical_not) {
+            if (logical == 0) {
+                logical = -1;
+            } else {
+                logical = -logical;
+            }
+        }
+        next_token(s);
+    }
+
+    te_expr *ret;
+
+    if (sign == 1) {
+        if (logical == 0) {
+            ret = base(s);
+        } else if (logical == -1) {
+            ret = NEW_EXPR(TE_FUNCTION1 | TE_FLAG_PURE, base(s));
+            ret->function = logical_not;
+        } else {
+            ret = NEW_EXPR(TE_FUNCTION1 | TE_FLAG_PURE, base(s));
+            ret->function = logical_notnot;
+        }
+    } else {
+        if (logical == 0) {
+            ret = NEW_EXPR(TE_FUNCTION1 | TE_FLAG_PURE, base(s));
+            ret->function = negate;
+        } else if (logical == -1) {
+            ret = NEW_EXPR(TE_FUNCTION1 | TE_FLAG_PURE, base(s));
+            ret->function = negate_logical_not;
+        } else {
+            ret = NEW_EXPR(TE_FUNCTION1 | TE_FLAG_PURE, base(s));
+            ret->function = negate_logical_notnot;
+        }
+    }
+
+    return ret;
+}
+
+#ifdef TE_POW_FROM_RIGHT
+static te_expr *factor(state *s) {
+    /* <factor>    =    <power> {"^" <power>} */
+    te_expr *ret = power(s);
+
+    const void *left_function = NULL;
+    te_expr *insertion = 0;
+
+    if (ret->type == (TE_FUNCTION1 | TE_FLAG_PURE) &&
+        (ret->function == negate || ret->function == logical_not || ret->function == logical_notnot ||
+        ret->function == negate_logical_not || ret->function == negate_logical_notnot)) {
+        left_function = ret->function;
+        te_expr *se = ret->parameters[0];
+        free(ret);
+        ret = se;
+    }
+
+    while (s->type == TOK_INFIX && (s->function == pow)) {
+        te_fun2 t = s->function;
+        next_token(s);
+
+        if (insertion) {
+            /* Make exponentiation go right-to-left. */
+            te_expr *insert = NEW_EXPR(TE_FUNCTION2 | TE_FLAG_PURE, insertion->parameters[1], power(s));
+            insert->function = t;
+            insertion->parameters[1] = insert;
+            insertion = insert;
+        } else {
+            ret = NEW_EXPR(TE_FUNCTION2 | TE_FLAG_PURE, ret, power(s));
+            ret->function = t;
+            insertion = ret;
+        }
+    }
+
+    if (left_function) {
+        ret = NEW_EXPR(TE_FUNCTION1 | TE_FLAG_PURE, ret);
+        ret->function = left_function;
+    }
+
+    return ret;
+}
+#else
+static te_expr *factor(state *s) {
+    /* <factor>    =    <power> {"^" <power>} */
+    te_expr *ret = power(s);
+
+    while (s->type == TOK_INFIX && (s->function == pow)) {
+        te_fun2 t = s->function;
+        next_token(s);
+        ret = NEW_EXPR(TE_FUNCTION2 | TE_FLAG_PURE, ret, power(s));
+        ret->function = t;
+    }
+
+    return ret;
+}
+#endif
+
+
+
+static te_expr *term(state *s) {
+    /* <term>      =    <factor> {("*" | "/" | "%") <factor>} */
+    te_expr *ret = factor(s);
+
+    while (s->type == TOK_INFIX && (s->function == mul || s->function == divide || s->function == fmod)) {
+        te_fun2 t = s->function;
+        next_token(s);
+        ret = NEW_EXPR(TE_FUNCTION2 | TE_FLAG_PURE, ret, factor(s));
+        ret->function = t;
+    }
+
+    return ret;
+}
+
+
+static te_expr *sum_expr(state *s) {
+    /* <expr>      =    <term> {("+" | "-") <term>} */
+    te_expr *ret = term(s);
+
+    while (s->type == TOK_INFIX && (s->function == add || s->function == sub)) {
+        te_fun2 t = s->function;
+        next_token(s);
+        ret = NEW_EXPR(TE_FUNCTION2 | TE_FLAG_PURE, ret, term(s));
+        ret->function = t;
+    }
+
+    return ret;
+}
+
+
+static te_expr *test_expr(state *s) {
+    /* <expr>      =    <sum_expr> {(">" | ">=" | "<" | "<=" | "==" | "!=") <sum_expr>} */
+    te_expr *ret = sum_expr(s);
+
+    while (s->type == TOK_INFIX && (s->function == greater || s->function == greater_eq ||
+        s->function == lower || s->function == lower_eq || s->function == equal || s->function == not_equal)) {
+        te_fun2 t = s->function;
+        next_token(s);
+        ret = NEW_EXPR(TE_FUNCTION2 | TE_FLAG_PURE, ret, sum_expr(s));
+        ret->function = t;
+    }
+
+    return ret;
+}
+
+
+static te_expr *expr(state *s) {
+    /* <expr>      =    <test_expr> {("&&" | "||") <test_expr>} */
+    te_expr *ret = test_expr(s);
+
+    while (s->type == TOK_INFIX && (s->function == logical_and || s->function == logical_or)) {
+        te_fun2 t = s->function;
+        next_token(s);
+        ret = NEW_EXPR(TE_FUNCTION2 | TE_FLAG_PURE, ret, test_expr(s));
+        ret->function = t;
+    }
+
+    return ret;
+}
+
+
+static te_expr *list(state *s) {
+    /* <list>      =    <expr> {"," <expr>} */
+    te_expr *ret = expr(s);
+
+    while (s->type == TOK_SEP) {
+        next_token(s);
+        ret = NEW_EXPR(TE_FUNCTION2 | TE_FLAG_PURE, ret, expr(s));
+        ret->function = comma;
+    }
+
+    return ret;
+}
+
+
+#define TE_FUN(...) ((double(*)(__VA_ARGS__))n->function)
+#define M(e) te_eval(n->parameters[e])
+
+
+double te_eval(const te_expr *n) {
+    if (!n) return NAN;
+
+    switch(TYPE_MASK(n->type)) {
+        case TE_CONSTANT: return n->value;
+        case TE_VARIABLE: return *n->bound;
+
+        case TE_FUNCTION0: case TE_FUNCTION1: case TE_FUNCTION2: case TE_FUNCTION3:
+        case TE_FUNCTION4: case TE_FUNCTION5: case TE_FUNCTION6: case TE_FUNCTION7:
+            switch(ARITY(n->type)) {
+                case 0: return TE_FUN(void)();
+                case 1: return TE_FUN(double)(M(0));
+                case 2: return TE_FUN(double, double)(M(0), M(1));
+                case 3: return TE_FUN(double, double, double)(M(0), M(1), M(2));
+                case 4: return TE_FUN(double, double, double, double)(M(0), M(1), M(2), M(3));
+                case 5: return TE_FUN(double, double, double, double, double)(M(0), M(1), M(2), M(3), M(4));
+                case 6: return TE_FUN(double, double, double, double, double, double)(M(0), M(1), M(2), M(3), M(4), M(5));
+                case 7: return TE_FUN(double, double, double, double, double, double, double)(M(0), M(1), M(2), M(3), M(4), M(5), M(6));
+                default: return NAN;
+            }
+
+        case TE_CLOSURE0: case TE_CLOSURE1: case TE_CLOSURE2: case TE_CLOSURE3:
+        case TE_CLOSURE4: case TE_CLOSURE5: case TE_CLOSURE6: case TE_CLOSURE7:
+            switch(ARITY(n->type)) {
+                case 0: return TE_FUN(void*)(n->parameters[0]);
+                case 1: return TE_FUN(void*, double)(n->parameters[1], M(0));
+                case 2: return TE_FUN(void*, double, double)(n->parameters[2], M(0), M(1));
+                case 3: return TE_FUN(void*, double, double, double)(n->parameters[3], M(0), M(1), M(2));
+                case 4: return TE_FUN(void*, double, double, double, double)(n->parameters[4], M(0), M(1), M(2), M(3));
+                case 5: return TE_FUN(void*, double, double, double, double, double)(n->parameters[5], M(0), M(1), M(2), M(3), M(4));
+                case 6: return TE_FUN(void*, double, double, double, double, double, double)(n->parameters[6], M(0), M(1), M(2), M(3), M(4), M(5));
+                case 7: return TE_FUN(void*, double, double, double, double, double, double, double)(n->parameters[7], M(0), M(1), M(2), M(3), M(4), M(5), M(6));
+                default: return NAN;
+            }
+
+        default: return NAN;
+    }
+
+}
+
+#undef TE_FUN
+#undef M
+
+static void optimize(te_expr *n) {
+    /* Evaluates as much as possible. */
+    if (n->type == TE_CONSTANT) return;
+    if (n->type == TE_VARIABLE) return;
+
+    /* Only optimize out functions flagged as pure. */
+    if (IS_PURE(n->type)) {
+        const int arity = ARITY(n->type);
+        int known = 1;
+        int i;
+        for (i = 0; i < arity; ++i) {
+            optimize(n->parameters[i]);
+            if (((te_expr*)(n->parameters[i]))->type != TE_CONSTANT) {
+                known = 0;
+            }
+        }
+        if (known) {
+            const double value = te_eval(n);
+            te_free_parameters(n);
+            n->type = TE_CONSTANT;
+            n->value = value;
+        }
+    }
+}
+
+
+te_expr *te_compile(const char *expression, const te_variable *variables, int var_count, int *error) {
+    state s;
+    s.start = s.next = expression;
+    s.lookup = variables;
+    s.lookup_len = var_count;
+
+    next_token(&s);
+    te_expr *root = list(&s);
+
+    if (s.type != TOK_END) {
+        te_free(root);
+        if (error) {
+            *error = (s.next - s.start);
+            if (*error == 0) *error = 1;
+        }
+        return 0;
+    } else {
+        optimize(root);
+        if (error) *error = 0;
+        return root;
+    }
+}
+
+
+double te_interp(const char *expression, int *error) {
+    te_expr *n = te_compile(expression, 0, 0, error);
+    double ret;
+    if (n) {
+        ret = te_eval(n);
+        te_free(n);
+    } else {
+        ret = NAN;
+    }
+    return ret;
+}
+
+static void pn (const te_expr *n, int depth) {
+    int i, arity;
+    printf("%*s", depth, "");
+
+    switch(TYPE_MASK(n->type)) {
+    case TE_CONSTANT: printf("%f\n", n->value); break;
+    case TE_VARIABLE: printf("bound %p\n", n->bound); break;
+
+    case TE_FUNCTION0: case TE_FUNCTION1: case TE_FUNCTION2: case TE_FUNCTION3:
+    case TE_FUNCTION4: case TE_FUNCTION5: case TE_FUNCTION6: case TE_FUNCTION7:
+    case TE_CLOSURE0: case TE_CLOSURE1: case TE_CLOSURE2: case TE_CLOSURE3:
+    case TE_CLOSURE4: case TE_CLOSURE5: case TE_CLOSURE6: case TE_CLOSURE7:
+         arity = ARITY(n->type);
+         printf("f%d", arity);
+         for(i = 0; i < arity; i++) {
+             printf(" %p", n->parameters[i]);
+         }
+         printf("\n");
+         for(i = 0; i < arity; i++) {
+             pn(n->parameters[i], depth + 1);
+         }
+         break;
+    }
+}
+
+
+void te_print(const te_expr *n) {
+    pn(n, 0);
+}

--- a/src/utils/tinyexpr/tinyexpr.h
+++ b/src/utils/tinyexpr/tinyexpr.h
@@ -1,0 +1,86 @@
+/*
+ * TINYEXPR - Tiny recursive descent parser and evaluation engine in C
+ *
+ * Copyright (c) 2015-2018 Lewis Van Winkle
+ *
+ * http://CodePlea.com
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ * claim that you wrote the original software. If you use this software
+ * in a product, an acknowledgement in the product documentation would be
+ * appreciated but is not required.
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ * 3. This notice may not be removed or altered from any source distribution.
+ */
+
+#ifndef __TINYEXPR_H__
+#define __TINYEXPR_H__
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+
+typedef struct te_expr {
+    int type;
+    union {double value; const double *bound; const void *function;};
+    void *parameters[1];
+} te_expr;
+
+
+enum {
+    TE_VARIABLE = 0,
+
+    TE_FUNCTION0 = 8, TE_FUNCTION1, TE_FUNCTION2, TE_FUNCTION3,
+    TE_FUNCTION4, TE_FUNCTION5, TE_FUNCTION6, TE_FUNCTION7,
+
+    TE_CLOSURE0 = 16, TE_CLOSURE1, TE_CLOSURE2, TE_CLOSURE3,
+    TE_CLOSURE4, TE_CLOSURE5, TE_CLOSURE6, TE_CLOSURE7,
+
+    TE_FLAG_PURE = 32
+};
+
+typedef struct te_variable {
+    const char *name;
+    const void *address;
+    int type;
+    void *context;
+} te_variable;
+
+
+
+/* Parses the input expression, evaluates it, and frees it. */
+/* Returns NaN on error. */
+double te_interp(const char *expression, int *error);
+
+/* Parses the input expression and binds variables. */
+/* Returns NULL on error. */
+te_expr *te_compile(const char *expression, const te_variable *variables, int var_count, int *error);
+
+/* Evaluates the expression. */
+double te_eval(const te_expr *n);
+
+/* Prints debugging information on the syntax tree. */
+void te_print(const te_expr *n);
+
+/* Frees the expression. */
+/* This is safe to call on NULL pointers. */
+void te_free(te_expr *n);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /*__TINYEXPR_H__*/


### PR DESCRIPTION
Let the user define the behavior of the watchface with expression based on internal values.

Examples: 

* use math expression for display label: `{..."type":"expr","expr":"steps()/2"...}` to display half step value
* use bool expression to display image: `{..."enable":"bluetooth_messages()>0"...` to display an image when there are messages
* use math expression to rotate image: `{..."rotation":"0 + ( ( tm_hour * 364 ) / 24)"...}` to display hour or `{..."rotation":"10 + ( battery_percent * 170 / 100)"...}` to display a gauge for battery
* ...

Main ideas:
* offer full power/expressivity to watchface designer
* add more dynamic controls (enable a part based on context)