### PR TITLE
Fix of short IR configs

### DIFF
--- a/src/app/IRController/IRConfig.cpp
+++ b/src/app/IRController/IRConfig.cpp
@@ -134,7 +134,7 @@
 
         // Increase buttons treshold further and leave space for adding buttons via bluetooth
         if (jsonButtonCount > IR_BUTTONS_START - IR_BUTTONS_TRESHOLD) {
-            free(buttons);
+            if (buttons != nullptr) free(buttons);
             buttons = (InfraButton**)MALLOC(sizeof( InfraButton* ) * (jsonButtonCount + IR_BUTTONS_TRESHOLD));
             if (buttons) {
                 log_d("alloc more infrared buttons from %d to %d successful", IR_BUTTONS_START, (jsonButtonCount + IR_BUTTONS_TRESHOLD));
@@ -143,6 +143,8 @@
                 log_e("alloc more infrared buttons failed");
                 while( true );
             }
+        } else if (buttons == nullptr) {
+            buttons = (InfraButton**)MALLOC(sizeof( InfraButton* ) * IR_BUTTONS_START);
         }
 
         for (size_t i = 0; i < pageCount; i++)

--- a/src/app/IRController/IRConfig.h
+++ b/src/app/IRController/IRConfig.h
@@ -41,7 +41,7 @@
                 virtual size_t getJsonBufferSize() { return 48000; }
 
                 protected:
-                InfraButton** buttons = (InfraButton**)MALLOC(sizeof( InfraButton* ) * IR_BUTTONS_START);
+                InfraButton** buttons = nullptr;
                 size_t buttonCount = 0;
             };
         #else


### PR DESCRIPTION
Moved the IR buttons allocation to fix bootloop with shorter configs. I cannot really explain, why it fixes the problem, but I guess it has something to do with the sizeof of InfraButton being a different size later in the execution.

https://github.com/d03n3rfr1tz3/TTGO.T-Watch.2020/issues/20