### PR TITLE
Add Model characteristics to Device Info Service

### DIFF
--- a/src/hardware/ble/deviceinfo.cpp
+++ b/src/hardware/ble/deviceinfo.cpp
@@ -37,6 +37,8 @@ void deviceinfo_setup( void ) {
         pManufacturerNameStringCharacteristic->setValue("Lily Go");
         NimBLECharacteristic* pFirmwareRevisionStringCharacteristic = pDeviceInformationService->createCharacteristic( FIRMWARE_REVISION_STRING_CHARACTERISTIC_UUID, NIMBLE_PROPERTY::READ );
         pFirmwareRevisionStringCharacteristic->setValue(__FIRMWARE__);
+        NimBLECharacteristic* pModelStringCharacteristic = pDeviceInformationService->createCharacteristic( MODEL_STRING_CHARACTERISTIC_UUID, NIMBLE_PROPERTY::READ );
+        pModelStringCharacteristic->setValue(HARDWARE_NAME);
         pDeviceInformationService->start();
         pAdvertising->addServiceUUID( pDeviceInformationService->getUUID() );
     #endif

--- a/src/hardware/ble/deviceinfo.h
+++ b/src/hardware/ble/deviceinfo.h
@@ -28,6 +28,7 @@
     #define DEVICE_INFORMATION_SERVICE_UUID                 (uint16_t)0x180A                           /** @brief Device Information server UUID */
     #define MANUFACTURER_NAME_STRING_CHARACTERISTIC_UUID    (uint16_t)0x2A29                           /** @brief Device Information - manufacturer name string UUID */
     #define FIRMWARE_REVISION_STRING_CHARACTERISTIC_UUID    (uint16_t)0x2A26                           /** @brief Device Information - firmware revision UUID */
+    #define MODEL_STRING_CHARACTERISTIC_UUID                (uint16_t)0x2A24                           /** @brief Device Information - model UUID */
     /**
      * @brief setup gadgetbridge transmit/recieve over ble
      */


### PR DESCRIPTION
Device Information Service specifies [1] following of characteristics:
- Manufacturer Name String
- Model Number String
- Serial Number String
- Hardware Revision String
- Firmware Revision String
- Software Revision String
- System ID
- IEEE 11073-20601 Regulatory
- Certification Data List
- PnP ID

Following two are already implemented:
- Manufacturer Name String
- Hardware Revision String

I have used Model Number String to display HARDWARE_NAME string.

https://www.bluetooth.com/specifications/specs/device-information-service-1-1/

Here is a screenshot how it looks like with Amazfish:

![image](https://github.com/user-attachments/assets/44f942d0-88fd-4237-8889-d97447807704)

